### PR TITLE
PSY-98 - Add is_read column to swap_requests

### DIFF
--- a/backend/Migrations/20260304191833_AddIsReadToSwapRequests.Designer.cs
+++ b/backend/Migrations/20260304191833_AddIsReadToSwapRequests.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MedicalDemo.Models.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace MedicalDemo.Migrations
 {
     [DbContext(typeof(MedicalContext))]
-    partial class MedicalContextModelSnapshot : ModelSnapshot
+    [Migration("20260304191833_AddIsReadToSwapRequests")]
+    partial class AddIsReadToSwapRequests
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20260304191833_AddIsReadToSwapRequests.cs
+++ b/backend/Migrations/20260304191833_AddIsReadToSwapRequests.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MedicalDemo.Migrations
+{
+    public partial class AddIsReadToSwapRequests : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "is_read",
+                table: "swap_requests",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "is_read",
+                table: "swap_requests");
+        }
+    }
+}

--- a/backend/Models/Entities/SwapRequest.cs
+++ b/backend/Models/Entities/SwapRequest.cs
@@ -14,6 +14,7 @@ namespace MedicalDemo.Models.Entities
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
         public string? Details { get; set; }
+        public bool IsRead { get; set; } = false;
 
         public virtual Resident Requestee { get; set; } = null!;
         public virtual Resident Requester { get; set; } = null!;


### PR DESCRIPTION
Add a boolean is_read column to the swap_requests table to track whether an admin has acknowledged a swap request.