### PR TITLE
Psy 107 add get api dates call types

### DIFF
--- a/backend/Controllers/DatesControllers.cs
+++ b/backend/Controllers/DatesControllers.cs
@@ -114,6 +114,18 @@ public class DatesController : ControllerBase
         return Ok(results);
     }
 
+    // GET: api/dates/call-types
+    [HttpGet("call-types")]
+    public async Task<ActionResult<IEnumerable<DateCallTypeShiftResponse>>>
+        GetCallShiftType(
+            [FromBody] DateOnly date, [FromQuery] int graduateYr)
+    {
+        // returns valid call type given year and date, if null returns custom shift
+        CallShiftType resultCallType = CallShiftTypeExtensions.GetAlgorithmCallShiftTypeForDate(date, graduateYr) ?? CallShiftType.Custom;
+
+        return Ok(new DateCallTypeShiftResponse(resultCallType));
+    }
+
     // GET: api/dates/published
     [HttpGet("published")]
     public async Task<ActionResult<IEnumerable<DateResponse>>>

--- a/backend/Controllers/DatesControllers.cs
+++ b/backend/Controllers/DatesControllers.cs
@@ -124,8 +124,8 @@ public class DatesController : ControllerBase
             [FromQuery] string resident_id,
             [FromQuery] DateOnly date)
     {
-        (bool checkPassed, string? checkError) = await _ruleViolationService.CheckResidentScheduledOnDate(schedule_id, resident_id, date);
-        if (!checkPassed)
+        (bool checkPassed, string? checkError, Resident? resident) = await _ruleViolationService.CheckResidentScheduledOnDate(schedule_id, resident_id, date);
+        if (!checkPassed || resident == null)
         {
             return BadRequest(new GenericResponse()
             {
@@ -134,29 +134,8 @@ public class DatesController : ControllerBase
             });
         }
 
-        // calc PGYear offset, if any
-        (bool Success, string? offsetError, int offset)
-            = await _ruleViolationService.CalcPGYearOffset(schedule_id, resident_id, date);
-        if (!Success)
-        {
-            return NotFound(new GenericResponse()
-            {
-                Success = false,
-                Message = offsetError
-            });
-        }
-
         // calc gradYr accounting for PGYear offset, if any
-        (bool success, string? calcGradYearError, int graduateYr)
-            = await _ruleViolationService.CalcGradYearWOffset(resident_id, offset);
-        if (!success)
-        {
-            return NotFound(new GenericResponse()
-            {
-                Success = false,
-                Message = calcGradYearError
-            });
-        }
+        int graduateYr = ResidentExtensions.GetGraduateYrForDate(resident, date);
 
         // returns valid call type given year and date, if null returns custom shift
         CallShiftType resultCallType =

--- a/backend/Controllers/DatesControllers.cs
+++ b/backend/Controllers/DatesControllers.cs
@@ -7,6 +7,7 @@ using MedicalDemo.Models.DTO.Requests;
 using MedicalDemo.Models.DTO.Responses;
 using MedicalDemo.Models.DTO.Scheduling;
 using MedicalDemo.Models.Entities;
+using MedicalDemo.Services;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -20,6 +21,7 @@ public class DatesController : ControllerBase
     private readonly ILogger<DatesController> _logger;
     private readonly MedicalContext _context;
     private readonly DateConverter _dateConverter;
+    private readonly RuleViolationService _ruleViolationService;
 
     public DatesController(MedicalContext context, DateConverter dateConverter, ILogger<DatesController> logger)
     {
@@ -116,14 +118,58 @@ public class DatesController : ControllerBase
 
     // GET: api/dates/call-types
     [HttpGet("call-types")]
-    public async Task<ActionResult<IEnumerable<DateCallTypeShiftResponse>>>
+    public async Task<ActionResult<DateCallTypeShiftListResponse>>
         GetCallShiftType(
-            [FromBody] DateOnly date, [FromQuery] int graduateYr)
+            [FromQuery] Guid schedule_id,
+            [FromQuery] string resident_id,
+            [FromQuery] DateOnly date)
     {
-        // returns valid call type given year and date, if null returns custom shift
-        CallShiftType resultCallType = CallShiftTypeExtensions.GetAlgorithmCallShiftTypeForDate(date, graduateYr) ?? CallShiftType.Custom;
+        (bool checkPassed, string? checkError) = await _ruleViolationService.CheckResidentScheduledOnDate(schedule_id, resident_id, date);
+        if (!checkPassed)
+        {
+            return BadRequest(new GenericResponse()
+            {
+                Success = false,
+                Message = checkError
+            });
+        }
 
-        return Ok(new DateCallTypeShiftResponse(resultCallType));
+        // calc PGYear offset, if any
+        (bool Success, string? offsetError, int offset)
+            = await _ruleViolationService.CalcPGYearOffset(schedule_id, resident_id, date);
+        if (!Success)
+        {
+            return NotFound(new GenericResponse()
+            {
+                Success = false,
+                Message = offsetError
+            });
+        }
+
+        // calc gradYr accounting for PGYear offset, if any
+        (bool success, string? calcGradYearError, int graduateYr)
+            = await _ruleViolationService.CalcGradYearWOffset(resident_id, offset);
+        if (!success)
+        {
+            return NotFound(new GenericResponse()
+            {
+                Success = false,
+                Message = calcGradYearError
+            });
+        }
+
+        // returns valid call type given year and date, if null returns custom shift
+        CallShiftType resultCallType =
+            CallShiftTypeExtensions.GetAlgorithmCallShiftTypeForDate(date, graduateYr) ?? CallShiftType.Custom;
+
+        List<DateCallTypeShiftResponse> resultCallTypes = new() { new DateCallTypeShiftResponse(resultCallType) };
+
+        if (resultCallType != CallShiftType.Custom)
+        {
+            resultCallTypes.Add(new DateCallTypeShiftResponse(CallShiftType.Custom));
+        }
+
+        return Ok(resultCallTypes);
     }
 
     // GET: api/dates/published

--- a/backend/Controllers/DatesControllers.cs
+++ b/backend/Controllers/DatesControllers.cs
@@ -23,11 +23,17 @@ public class DatesController : ControllerBase
     private readonly DateConverter _dateConverter;
     private readonly RuleViolationService _ruleViolationService;
 
-    public DatesController(MedicalContext context, DateConverter dateConverter, ILogger<DatesController> logger)
+    public DatesController(
+        MedicalContext context,
+        DateConverter dateConverter,
+        ILogger<DatesController> logger,
+        RuleViolationService ruleViolationService
+    )
     {
         _context = context;
         _dateConverter = dateConverter;
         _logger = logger;
+        _ruleViolationService = ruleViolationService;
     }
 
     // POST: api/dates
@@ -130,18 +136,18 @@ public class DatesController : ControllerBase
             return BadRequest(new GenericResponse()
             {
                 Success = false,
-                Message = checkError
+                Message = checkError ?? "Failed to check if resident was scheduled on date"
             });
         }
 
         // calc gradYr accounting for PGYear offset, if any
-        int graduateYr = ResidentExtensions.GetGraduateYrForDate(resident, date);
+        int graduateYr = resident.GetGraduateYrForDate(date);
 
         // returns valid call type given year and date, if null returns custom shift
         CallShiftType resultCallType =
             CallShiftTypeExtensions.GetAlgorithmCallShiftTypeForDate(date, graduateYr) ?? CallShiftType.Custom;
 
-        List<DateCallTypeShiftResponse> resultCallTypes = new() { new DateCallTypeShiftResponse(resultCallType) };
+        List<DateCallTypeShiftResponse> resultCallTypes = [new(resultCallType)];
 
         if (resultCallType != CallShiftType.Custom)
         {

--- a/backend/Enums/CallShiftType.cs
+++ b/backend/Enums/CallShiftType.cs
@@ -7,7 +7,7 @@ public enum CallShiftType
 {
     // Standard call shift types
     [CallShift(Hours = 3, CallLengthType = CallLengthType.Short, DateRule = CallShiftRule.Weekday)]
-    [Display(Name = "Short")]
+    [Display(Name = "Short (3h)")]
     WeekdayShortCall = 0,
 
     [CallShift(Hours = 24, CallLengthType = CallLengthType.Long, ApplicableDays = [DayOfWeek.Saturday], RequiredPgy = 1)]

--- a/backend/Extensions/DateTimeExtensions.cs
+++ b/backend/Extensions/DateTimeExtensions.cs
@@ -1,14 +1,18 @@
+using MedicalDemo.Enums;
+
 namespace MedicalDemo.Extensions;
 
 public static class DateTimeExtensions
 {
     extension(DateTime dateTime)
     {
-        public int AcademicYear => dateTime.Month >= 7 ? dateTime.Year : dateTime.Year - 1;
+        public int AcademicYear => DateOnly.FromDateTime(dateTime).AcademicYear;
+        public Semester Semester => DateOnly.FromDateTime(dateTime).Semester;
     }
 
     extension(DateOnly date)
     {
         public int AcademicYear => date.Month >= 7 ? date.Year : date.Year - 1;
+        public Semester Semester => date.Month >= 7 ? Semester.Fall : Semester.Spring;
     }
 }

--- a/backend/Extensions/DateTimeExtensions.cs
+++ b/backend/Extensions/DateTimeExtensions.cs
@@ -6,4 +6,9 @@ public static class DateTimeExtensions
     {
         public int AcademicYear => dateTime.Month >= 7 ? dateTime.Year : dateTime.Year - 1;
     }
+
+    extension(DateOnly date)
+    {
+        public int AcademicYear => date.Month >= 7 ? date.Year : date.Year - 1;
+    }
 }

--- a/backend/Extensions/ResidentExtensions.cs
+++ b/backend/Extensions/ResidentExtensions.cs
@@ -1,0 +1,29 @@
+using MedicalDemo.Enums;
+using MedicalDemo.Models.Entities;
+
+namespace MedicalDemo.Extensions;
+
+public static class ResidentExtensions
+{
+    public static int GetGraduateYrForDate(this Resident resident, DateOnly date)
+    {
+        int graduateYr = GetGraduateYrForSemesterAndYear(resident, date.Semester, date.Year);
+        return graduateYr;
+    }
+
+    public static int GetGraduateYrForSemesterAndYear(this Resident resident, Semester semester, int year)
+    {
+        int offset = 0;
+        int currAcademicYear = DateTime.Now.AcademicYear;
+        int inputtedDateAcademicYear = semester == Semester.Fall ? year : year - 1;
+
+        // calc how many academic years ahead of today the manual date is
+        if (inputtedDateAcademicYear > currAcademicYear)
+        {
+            offset = inputtedDateAcademicYear - currAcademicYear;
+        }
+
+        int graduateYr = resident.GraduateYr + offset;
+        return (graduateYr);
+    }
+}

--- a/backend/Extensions/WebApplicationBuilderExtensions.cs
+++ b/backend/Extensions/WebApplicationBuilderExtensions.cs
@@ -40,6 +40,7 @@ public static class WebApplicationBuilderExtensions
         builder.Services.AddScoped<SchedulerService>();
         builder.Services.AddScoped<AlgorithmService>();
         builder.Services.AddScoped<DatabaseSeeder>();
+        builder.Services.AddScoped<RuleViolationService>();
         builder.Services.AddScoped<Pgy4RotationScheduleService>();
         builder.Services.AddTransient<Pgy4RotationScheduleGenerator>();
 

--- a/backend/Models/DTO/Responses/DateCallTypeShiftListResponse.cs
+++ b/backend/Models/DTO/Responses/DateCallTypeShiftListResponse.cs
@@ -1,0 +1,6 @@
+namespace MedicalDemo.Models.DTO.Responses;
+
+public class DateCallTypeShiftListResponse
+{
+    public List<DateCallTypeShiftResponse> EligibleDateCallShiftTypes { get; set; } = [];
+}

--- a/backend/Services/RuleViolationService.cs
+++ b/backend/Services/RuleViolationService.cs
@@ -1,0 +1,110 @@
+using MedicalDemo.Algorithms.OnCallScheduleGenerator;
+using MedicalDemo.Enums;
+using MedicalDemo.Extensions;
+using MedicalDemo.Models;
+using MedicalDemo.Models.DTO;
+using MedicalDemo.Models.DTO.Responses;
+using MedicalDemo.Models.DTO.Scheduling;
+using MedicalDemo.Models.Entities;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+
+namespace MedicalDemo.Services;
+
+public class RuleViolationService
+{
+    private readonly ILogger<SchedulerService> _logger;
+    private readonly AlgorithmService _algorithmService;
+    private readonly MedicalContext _context;
+    private readonly SchedulingMapperService _mapper;
+
+    public RuleViolationService(
+        MedicalContext context,
+        SchedulingMapperService mapper,
+        AlgorithmService algorithmService,
+        ILogger<SchedulerService> logger
+    )
+    {
+        _context = context;
+        _mapper = mapper;
+        _algorithmService = algorithmService;
+        _logger = logger;
+    }
+
+
+    public async Task<(bool Success, string? Error)> CheckResidentScheduledOnDate(
+        Guid schedule_id,
+        string resident_id,
+        DateOnly date
+        )
+    {
+        //validate schedule and resident
+        Schedule? schedule = await _context.Schedules.FindAsync(schedule_id);
+        if (schedule == null)
+        {
+            return (false, "Invalid ScheduleID.");
+        }
+
+        Resident? resident = await _context.Residents.FindAsync(resident_id);
+        if (resident == null)
+        {
+            return (false, "Invalid ResidentID.");
+        }
+
+        // check if shift exists for this resident on this day
+        bool residentScheduled = await _context.Dates
+            .AnyAsync(d =>
+                d.ResidentId == resident_id &&
+                d.ShiftDate == date);
+
+        if (residentScheduled)
+        {
+            return (false, "Resident is already scheduled on this date.");
+        }
+
+        return (true, null);
+    }
+
+    public async Task<(bool Success, string? Error, int offset)> CalcPGYearOffset(
+        Guid schedule_id, string resident_id, DateOnly date)
+    {
+        //validate schedule and resident
+        Schedule? schedule = await _context.Schedules.FindAsync(schedule_id);
+        if (schedule == null)
+        {
+            return (false, "Invalid ScheduleID.", -1);
+        }
+
+        Resident? resident = await _context.Residents.FindAsync(resident_id);
+        if (resident == null)
+        {
+            return (false, "Invalid ResidentID.", -1);
+        }
+
+        // calc how many academic years ahead of today the manual date is
+        int offset = 0;
+        if (date.AcademicYear > DateTime.Now.AcademicYear)
+        {
+            offset = date.AcademicYear - DateTime.Now.AcademicYear;
+        }
+
+        return (true, null, offset);
+
+    }
+
+    public async Task<(bool Success, string? Error, int graduateYr)> CalcGradYearWOffset(string resident_id, int offset)
+    {
+        Resident? resident = await _context.Residents.FindAsync(resident_id);
+        if (resident == null)
+        {
+            return (false, "Invalid ResidentID.", -1);
+        }
+
+        int graduateYr = resident.GraduateYr;
+
+        graduateYr += offset;
+
+        return (true, null, graduateYr);
+
+    }
+}

--- a/backend/Services/RuleViolationService.cs
+++ b/backend/Services/RuleViolationService.cs
@@ -32,7 +32,7 @@ public class RuleViolationService
     }
 
 
-    public async Task<(bool Success, string? Error)> CheckResidentScheduledOnDate(
+    public async Task<(bool Success, string? Error, Resident? resident)> CheckResidentScheduledOnDate(
         Guid schedule_id,
         string resident_id,
         DateOnly date
@@ -42,69 +42,27 @@ public class RuleViolationService
         Schedule? schedule = await _context.Schedules.FindAsync(schedule_id);
         if (schedule == null)
         {
-            return (false, "Invalid ScheduleID.");
+            return (false, "Invalid ScheduleID.", null);
         }
 
         Resident? resident = await _context.Residents.FindAsync(resident_id);
         if (resident == null)
         {
-            return (false, "Invalid ResidentID.");
+            return (false, "Invalid ResidentID.", null);
         }
 
         // check if shift exists for this resident on this day
         bool residentScheduled = await _context.Dates
             .AnyAsync(d =>
+                d.ScheduleId == schedule_id &&
                 d.ResidentId == resident_id &&
                 d.ShiftDate == date);
 
         if (residentScheduled)
         {
-            return (false, "Resident is already scheduled on this date.");
+            return (false, $"Resident is already scheduled on this date. Resident: {resident_id}, Schedule:{schedule_id},Date:{date}", resident);
         }
 
-        return (true, null);
-    }
-
-    public async Task<(bool Success, string? Error, int offset)> CalcPGYearOffset(
-        Guid schedule_id, string resident_id, DateOnly date)
-    {
-        //validate schedule and resident
-        Schedule? schedule = await _context.Schedules.FindAsync(schedule_id);
-        if (schedule == null)
-        {
-            return (false, "Invalid ScheduleID.", -1);
-        }
-
-        Resident? resident = await _context.Residents.FindAsync(resident_id);
-        if (resident == null)
-        {
-            return (false, "Invalid ResidentID.", -1);
-        }
-
-        // calc how many academic years ahead of today the manual date is
-        int offset = 0;
-        if (date.AcademicYear > DateTime.Now.AcademicYear)
-        {
-            offset = date.AcademicYear - DateTime.Now.AcademicYear;
-        }
-
-        return (true, null, offset);
-
-    }
-
-    public async Task<(bool Success, string? Error, int graduateYr)> CalcGradYearWOffset(string resident_id, int offset)
-    {
-        Resident? resident = await _context.Residents.FindAsync(resident_id);
-        if (resident == null)
-        {
-            return (false, "Invalid ResidentID.", -1);
-        }
-
-        int graduateYr = resident.GraduateYr;
-
-        graduateYr += offset;
-
-        return (true, null, graduateYr);
-
+        return (true, null, resident);
     }
 }


### PR DESCRIPTION
- Created API endpoint that accepts date, schedule_id, and resident_id and returns list of eligible call types and info using DateCallTypeShiftListResponse
- Created RuleViolationService.cs to implement logic checks: checks if resident is already scheduled on the selected date, calc offset, and calc GradYr (can be expanded in rule violation epic)
- added date to DateTimeExtensions to use in offset calc
- Created new response file DateCallTypeShiftListResponse.cs
- Edited CallShiftType.cs to include "Short (3h)"