### PR TITLE
PSY-123-PSY-97: Algo Feedback

### DIFF
--- a/backend/Algorithms/OnCallScheduleGenerator/AlgorithmService.cs
+++ b/backend/Algorithms/OnCallScheduleGenerator/AlgorithmService.cs
@@ -1814,7 +1814,8 @@ public class AlgorithmService
                     if (!found)
                     {
                         _logger.LogWarning("Unable to fix {curDay} for PGY{pgy} {name} ({id})", curDay, "1", res.Name, res.ResidentId);
-                        _logger.LogDebug("vacations: {vacations}", string.Join(", ", res.VacationRequests.Order()));
+                        _logger.LogDebug("morning vacations: {vacations}", string.Join(", ", res.MorningVacationRequests.Order()));
+                        _logger.LogDebug("afternoon vacations: {vacations}", string.Join(", ", res.AfternoonVacationRequests.Order()));
                         _logger.LogDebug("committed work days: {workdays}", string.Join(", ", res.CommitedWorkDays.Order()));
                         _logger.LogDebug("work days: {workdays}", string.Join(", ", res.WorkDays.Order()));
                         _logger.LogDebug("role: {role}", res.GetHospitalRoleForCalendarMonth(curDay.Month).ToString());
@@ -1944,7 +1945,8 @@ public class AlgorithmService
                     if (!found)
                     {
                         _logger.LogWarning("Unable to fix {curDay} for PGY{pgy} {name} ({id})", curDay, "2", res.Name, res.ResidentId);
-                        _logger.LogDebug("vacations: {vacations}", string.Join(", ", res.VacationRequests.Order()));
+                        _logger.LogDebug("morning vacations: {vacations}", string.Join(", ", res.MorningVacationRequests.Order()));
+                        _logger.LogDebug("afternoon vacations: {vacations}", string.Join(", ", res.AfternoonVacationRequests.Order()));
                         _logger.LogDebug("committed work days: {workdays}", string.Join(", ", res.CommitedWorkDays.Order()));
                         _logger.LogDebug("work days: {workdays}", string.Join(", ", res.WorkDays.Order()));
                         _logger.LogDebug("role: {role}", res.GetHospitalRoleForCalendarMonth(curDay.Month).ToString());

--- a/backend/Algorithms/OnCallScheduleGenerator/AlgorithmService.cs
+++ b/backend/Algorithms/OnCallScheduleGenerator/AlgorithmService.cs
@@ -940,7 +940,6 @@ public class AlgorithmService
 
         if (eligibleReceivers.Count == 0)
         {
-            _logger.LogWarning("No eligible receivers found.");
             return false;
         }
 
@@ -1061,7 +1060,6 @@ public class AlgorithmService
 
         if (eligibleGivers.Count == 0)
         {
-            _logger.LogWarning("No eligible givers found.");
             return false;
         }
 
@@ -1161,7 +1159,7 @@ public class AlgorithmService
                 for (int i = 0; i < pgy1s.Count; i++)
                 {
                     Pgy1Dto res = pgy1s[i];
-                    if (res.CanWork(curDay, pgy1ShiftType.Value.GetLengthType()) && !workedDays.Contains(curDay))
+                    if (res.CanWork(curDay) && !workedDays.Contains(curDay))
                     {
                         allowedCallTypes[i][pgy1ShiftType.Value]++;
                     }
@@ -1176,7 +1174,7 @@ public class AlgorithmService
                 for (int i = 0; i < pgy2s.Count; i++)
                 {
                     Pgy2Dto res = pgy2s[i];
-                    if (res.CanWork(curDay, pgy2ShiftType.Value.GetLengthType()) && !workedDays.Contains(curDay))
+                    if (res.CanWork(curDay) && !workedDays.Contains(curDay))
                     {
                         allowedCallTypes[i + pgy1s.Count][pgy2ShiftType.Value]++;
                     }
@@ -1326,7 +1324,7 @@ public class AlgorithmService
                     {
                         for (int i = 0; i < pgy1s.Count; i++)
                         {
-                            if (pgy1s[i].CanWork(curDay, shift.GetLengthType()))
+                            if (pgy1s[i].CanWork(curDay))
                             {
                                 g.addEdge(i * numShiftTypes + shiftOffset,
                                     shiftStart + dayList.Count - 1,
@@ -1339,7 +1337,7 @@ public class AlgorithmService
                     {
                         for (int i = 0; i < pgy2s.Count; i++)
                         {
-                            if (pgy2s[i].CanWork(curDay, shift.GetLengthType()))
+                            if (pgy2s[i].CanWork(curDay))
                             {
                                 g.addEdge(pgy2Start + i * numShiftTypes + shiftOffset,
                                     shiftStart + dayList.Count - 1,
@@ -1502,7 +1500,7 @@ public class AlgorithmService
             /*Console.WriteLine($"[DEBUG] fixing weekends");*/
 
             // fix weekends
-            if (FixWeekends1and2(pgy1s, pgy2s))
+            if (FixBackToBackShifts(pgy1s, pgy2s))
             {
                 return true; // all shifts were assigned correctly
             }
@@ -1581,7 +1579,7 @@ public class AlgorithmService
                     continue;
                 }
 
-                if (res.IsWorking(curDay) && !res.CanWork(curDay, curShiftType.Value.GetLengthType()))
+                if (res.IsWorking(curDay) && !res.CanWork(curDay))
                 {
                     bool found = false;
                     foreach (Pgy1Dto res2 in pgy1s)
@@ -1591,7 +1589,7 @@ public class AlgorithmService
                             continue;
                         }
 
-                        if (!res2.CanAddWorkDay(curDay, curShiftType.Value.GetLengthType()))
+                        if (!res2.CanAddWorkDay(curDay))
                         {
                             continue;
                         }
@@ -1614,7 +1612,7 @@ public class AlgorithmService
 
                             if (res2.IsWorking(otherDay)
                                 && curShiftType == otherShiftType
-                                && res.CanAddWorkDay(otherDay, otherShiftType.Value.GetLengthType()))
+                                && res.CanAddWorkDay(otherDay))
                             {
                                 found = true;
                                 SwapWorkDays1(res, res2, curDay, otherDay);
@@ -1642,8 +1640,7 @@ public class AlgorithmService
 
 
     public bool
-        FixWeekends1and2(List<Pgy1Dto> pgy1s,
-            List<Pgy2Dto> pgy2s) // function to fix resident weekends
+        FixBackToBackShifts(List<Pgy1Dto> pgy1s, List<Pgy2Dto> pgy2s) // function to fix resident weekends
     {
         bool successful = true;
         foreach (Pgy1Dto res in pgy1s)
@@ -1668,7 +1665,7 @@ public class AlgorithmService
                     continue;
                 }
 
-                if (res.IsWorking(curDay) && !res.CanWork(curDay, curShiftType.Value.GetLengthType()))
+                if (res.IsWorking(curDay) && !res.CanWork(curDay))
                 {
                     // They have this shift, it must be valid for their year
 
@@ -1681,7 +1678,7 @@ public class AlgorithmService
                             continue;
                         }
 
-                        if (!res2.CanAddWorkDay(curDay, curShiftType.Value.GetLengthType()))
+                        if (!res2.CanAddWorkDay(curDay))
                         {
                             continue;
                         }
@@ -1705,7 +1702,7 @@ public class AlgorithmService
 
                             if (res2.IsWorking(otherDay)
                                 && curShiftType == otherShiftType
-                                && res.CanAddWorkDay(otherDay, otherShiftType.Value.GetLengthType()))
+                                && res.CanAddWorkDay(otherDay))
                             {
                                 found = true;
                                 SwapWorkDays1(res, res2, curDay, otherDay);
@@ -1729,7 +1726,7 @@ public class AlgorithmService
                         {
                             foreach (Pgy2Dto res2 in pgy2s)
                             {
-                                if (!res2.CanAddWorkDay(curDay, curShiftTypeForPgy2.Value.GetLengthType()))
+                                if (!res2.CanAddWorkDay(curDay))
                                 {
                                     continue;
                                 }
@@ -1753,7 +1750,7 @@ public class AlgorithmService
 
                                     if (res2.IsWorking(otherDay)
                                         && curShiftType == otherShiftType
-                                        && res.CanAddWorkDay(otherDay, otherShiftType.Value.GetLengthType()))
+                                        && res.CanAddWorkDay(otherDay))
                                     {
                                         found = true;
                                         SwapWorkDays12(res, res2, curDay, otherDay);
@@ -1804,7 +1801,7 @@ public class AlgorithmService
                     continue;
                 }
 
-                if (res.IsWorking(curDay) && !res.CanWork(curDay, curShiftType.Value.GetLengthType()))
+                if (res.IsWorking(curDay) && !res.CanWork(curDay))
                 {
 
                     bool found = false;
@@ -1815,7 +1812,7 @@ public class AlgorithmService
                             continue;
                         }
 
-                        if (!res2.CanAddWorkDay(curDay, curShiftType.Value.GetLengthType()))
+                        if (!res2.CanAddWorkDay(curDay))
                         {
                             continue;
                         }
@@ -1839,7 +1836,7 @@ public class AlgorithmService
 
                             if (res2.IsWorking(otherDay)
                                 && curShiftType == otherShiftType
-                                && res.CanAddWorkDay(otherDay, otherShiftType.Value.GetLengthType()))
+                                && res.CanAddWorkDay(otherDay))
                             {
                                 found = true;
                                 SwapWorkDays2(res, res2, curDay, otherDay);
@@ -1863,7 +1860,7 @@ public class AlgorithmService
                         {
                             foreach (Pgy1Dto res2 in pgy1s)
                             {
-                                if (!res2.CanAddWorkDay(curDay, curShiftTypeForPgy1.Value.GetLengthType()))
+                                if (!res2.CanAddWorkDay(curDay))
                                 {
                                     continue;
                                 }
@@ -1883,7 +1880,7 @@ public class AlgorithmService
 
                                     if (res2.IsWorking(otherDay)
                                         && curShiftType == otherShiftType
-                                        && res.CanAddWorkDay(otherDay, otherShiftType.GetLengthType()))
+                                        && res.CanAddWorkDay(otherDay))
                                     {
                                         found = true;
                                         SwapWorkDays12(res2, res, otherDay, curDay);
@@ -1940,7 +1937,7 @@ public class AlgorithmService
                     continue;
                 }
 
-                if (res.IsWorking(curDay) && !res.CanWork(curDay, curShiftType.Value.GetLengthType()))
+                if (res.IsWorking(curDay) && !res.CanWork(curDay))
                 {
                     bool found = false;
                     foreach (Pgy2Dto res2 in pgy2s)
@@ -1950,7 +1947,7 @@ public class AlgorithmService
                             continue;
                         }
 
-                        if (!res2.CanAddWorkDay(curDay, curShiftType.Value.GetLengthType()))
+                        if (!res2.CanAddWorkDay(curDay))
                         {
                             continue;
                         }
@@ -1969,7 +1966,7 @@ public class AlgorithmService
                                     2)!.Value;
                             if (res2.IsWorking(otherDay)
                                 && curShiftType == otherShiftType
-                                && res.CanAddWorkDay(otherDay, otherShiftType.GetLengthType()))
+                                && res.CanAddWorkDay(otherDay))
                             {
                                 found = true;
                                 SwapWorkDays2(res, res2, curDay, otherDay);

--- a/backend/Algorithms/OnCallScheduleGenerator/AlgorithmService.cs
+++ b/backend/Algorithms/OnCallScheduleGenerator/AlgorithmService.cs
@@ -767,56 +767,66 @@ public class AlgorithmService
     {
         foreach (CallShiftType shift in shiftTypeCount.Keys)
         {
-            // Create a random ratio for each shift type
             for (int i = 0; i < shiftTypeCount[shift]; i++)
-            // randomly select a pgy1 or pgy2 to assign the shift to
             {
                 int? requiredYear = shift.GetRequiredYear();
-                int usingYear
-                    = requiredYear ?? (rand.NextDouble() < 0.50 ? 1 : 2); // 50% chance to assign to pgy1
+                int usingYear;
+
+                if (requiredYear.HasValue)
+                {
+                    usingYear = requiredYear.Value;
+                }
+                else
+                {
+                    // Sum total hours assigned so far across each group
+                    double pgy1Hours = pgy1ShiftCount
+                        .SelectMany(d => d)
+                        .Sum(kvp => kvp.Value * kvp.Key.GetHours());
+
+                    double pgy2Hours = pgy2ShiftCount
+                        .SelectMany(d => d)
+                        .Sum(kvp => kvp.Value * kvp.Key.GetHours());
+
+                    double totalHours = pgy1Hours + pgy2Hours;
+
+                    // If no hours yet, 50/50. Otherwise weight toward the group with fewer hours.
+                    double pgy1Probability = totalHours == 0 ? 0.5 : 1.0 - (pgy1Hours / totalHours);
+
+                    usingYear = rand.NextDouble() < pgy1Probability ? 1 : 2;
+                }
+
                 if (usingYear == 1)
                 {
-                    int pgy1Index = rand.Next(pgy1s.Count);
-                    if (!allowedCallTypes[pgy1Index]
-                            .ContainsKey(
-                                shift)) // check if the pgy1 cannot take this shift
+                    int pgy1Index = SelectWeightedIndex(pgy1ShiftCount, 0, pgy1s.Count, rand);
+                    if (!allowedCallTypes[pgy1Index].ContainsKey(shift))
                     {
                         i--;
                         continue;
                     }
 
-                    if (allowedCallTypes[pgy1Index][shift] ==
-                        pgy1ShiftCount[pgy1Index]
-                            [shift]) // if the pgy1 cannot take any shifts, skip this iteration
+                    if (allowedCallTypes[pgy1Index][shift] == pgy1ShiftCount[pgy1Index].GetValueOrDefault(shift))
                     {
                         i--;
                         continue;
                     }
-
 
                     if (!pgy1ShiftCount[pgy1Index].ContainsKey(shift))
                     {
                         pgy1ShiftCount[pgy1Index][shift] = 0;
                     }
 
-                    // initialize the count for this shift type
-                    pgy1ShiftCount[pgy1Index][shift]
-                        += 1; // increment the count for this shift type
+                    pgy1ShiftCount[pgy1Index][shift] += 1;
                 }
-                else // assign to pgy2
+                else
                 {
-                    int pgy2Index = rand.Next(pgy2s.Count);
-                    if (!allowedCallTypes[pgy2Index + pgy1s.Count]
-                            .ContainsKey(
-                                shift)) // check if the pgy2 cannot take this shift
+                    int pgy2Index = SelectWeightedIndex(pgy2ShiftCount, 0, pgy2s.Count, rand);
+                    if (!allowedCallTypes[pgy2Index + pgy1s.Count].ContainsKey(shift))
                     {
                         i--;
                         continue;
                     }
 
-                    if (allowedCallTypes[pgy2Index + pgy1s.Count][shift] ==
-                        pgy2ShiftCount[pgy2Index]
-                            [shift]) // if the pgy2 cannot take any shifts, skip this iteration
+                    if (allowedCallTypes[pgy2Index + pgy1s.Count][shift] == pgy2ShiftCount[pgy2Index].GetValueOrDefault(shift))
                     {
                         i--;
                         continue;
@@ -827,11 +837,53 @@ public class AlgorithmService
                         pgy2ShiftCount[pgy2Index][shift] = 0;
                     }
 
-                    // initialize the count for this shift type
                     pgy2ShiftCount[pgy2Index][shift] += 1;
                 }
             }
         }
+    }
+
+    private int SelectWeightedIndex(
+        Dictionary<CallShiftType, int>[] shiftCounts,
+        int startIndex, int count,
+        Random rand)
+    {
+        // Build weights: residents with fewer hours get higher weight
+        double[] weights = new double[count];
+        double maxHours = 0;
+
+        for (int i = 0; i < count; i++)
+        {
+            double hours = shiftCounts[startIndex + i]
+                .Sum(kvp => kvp.Value * kvp.Key.GetHours());
+            weights[i] = hours;
+            if (hours > maxHours)
+            {
+                maxHours = hours;
+            }
+        }
+
+        // Invert so fewer hours = higher weight, +1 to avoid zero weights
+        double totalWeight = 0;
+        for (int i = 0; i < count; i++)
+        {
+            weights[i] = (maxHours - weights[i]) + 1;
+            totalWeight += weights[i];
+        }
+
+        // Weighted random selection
+        double roll = rand.NextDouble() * totalWeight;
+        double cumulative = 0;
+        for (int i = 0; i < count; i++)
+        {
+            cumulative += weights[i];
+            if (roll < cumulative)
+            {
+                return i;
+            }
+        }
+
+        return count - 1;
     }
 
 #pragma warning restore IDE0060
@@ -1218,6 +1270,7 @@ public class AlgorithmService
                 if (ct2 > 100) // prevent infinite loop
                                //Console.WriteLine("Failed to find a valid assignment within 24-hour window after 100 attempts.");
                 {
+                    _logger.LogDebug("Failed with: Max: {max}, Min: {min}", max, min);
                     return false;
                 }
 

--- a/backend/Algorithms/OnCallScheduleGenerator/AlgorithmService.cs
+++ b/backend/Algorithms/OnCallScheduleGenerator/AlgorithmService.cs
@@ -887,31 +887,6 @@ public class AlgorithmService
     }
 
 #pragma warning restore IDE0060
-
-    public void SwapSomeShiftCount(List<Pgy1Dto> pgy1s, List<Pgy2Dto> pgy2s,
-        Dictionary<CallShiftType, int>[] pgy1ShiftCount,
-        Dictionary<CallShiftType, int>[] pgy2ShiftCount, Random rand, int[] pgy1WorkTime,
-        int[] pgy2WorkTime,
-        Dictionary<CallShiftType, int>[] allowedCallTypes)
-    {
-        // First root the person who worked the most
-        bool success = SwapWithGiverRooted(pgy1s, pgy2s, pgy1ShiftCount,
-            pgy2ShiftCount, rand, pgy1WorkTime, pgy2WorkTime, allowedCallTypes);
-
-        if (success)
-        {
-            return;
-        }
-
-        success = SwapWithReceiverRooted(pgy1s, pgy2s, pgy1ShiftCount,
-            pgy2ShiftCount, rand, pgy1WorkTime, pgy2WorkTime, allowedCallTypes);
-
-        if (!success)
-        {
-            _logger.LogWarning("Failed");
-        }
-    }
-
     public bool SwapWithGiverRooted(List<Pgy1Dto> pgy1s, List<Pgy2Dto> pgy2s,
         Dictionary<CallShiftType, int>[] pgy1ShiftCount,
         Dictionary<CallShiftType, int>[] pgy2ShiftCount, Random rand,
@@ -973,13 +948,16 @@ public class AlgorithmService
             int normalizedIndex = receiverYear == 1 ? i : i - pgy1s.Count;
             Dictionary<CallShiftType, int> shiftCount = receiverYear == 1 ? pgy1ShiftCount[normalizedIndex] : pgy2ShiftCount[normalizedIndex];
 
+            // Note on the Where/OrderBy: The swapping can lock up if it requires that the giver
+            // still stay on more. Instead, we require that the gap between them be smaller instead, and
+            // prioritize the shifts that decrease the gap the most
             List<CallShiftType> swappable = allowedCallTypes[i]
                 .Where(kvp => kvp.Value > shiftCount[kvp.Key])
                 .Select(kvp => kvp.Key)
                 .Intersect(giverShiftTypes)
-                .Where(s =>
-                    giveHour - s.GetHours() > receiverHour
-                )
+                .Where(s => Math.Abs(giveHour - s.GetHours() - (receiverHour + s.GetHours()))
+                            < Math.Abs(giveHour - receiverHour))
+                .OrderBy(s => Math.Abs(giveHour - s.GetHours() - (receiverHour + s.GetHours())))
                 .ToList();
 
             if (swappable.Count == 0)
@@ -1018,9 +996,13 @@ public class AlgorithmService
             : pgy2ShiftCount[normalizedReceiverIndex];
         IEnumerable<CallShiftType> receiverShiftTypes = allowedCallTypes[selectedReceiverIndex].Select(kvp => kvp.Key);
         List<CallShiftType> swappableShiftTypes = giverShiftTypes.Intersect(receiverShiftTypes).ToList();
+        int finalReceiverHour = finalReceiverYear == 1
+            ? pgy1WorkTime[normalizedReceiverIndex]
+            : pgy2WorkTime[normalizedReceiverIndex];
 
-        int shiftIndex = rand.Next(0, swappableShiftTypes.Count);
-        CallShiftType shift = swappableShiftTypes[shiftIndex];
+        CallShiftType shift = swappableShiftTypes
+            .OrderBy(s => Math.Abs(giveHour - s.GetHours() - (finalReceiverHour + s.GetHours())))
+            .First();
 
         giverShiftCount[shift]--;
         receiverShiftCount.TryAdd(shift, 0);
@@ -1095,11 +1077,16 @@ public class AlgorithmService
             int normalizedIndex = giverYear == 1 ? i : i - pgy1s.Count;
             Dictionary<CallShiftType, int> shiftCount = giverYear == 1 ? pgy1ShiftCount[normalizedIndex] : pgy2ShiftCount[normalizedIndex];
 
+            // Note on the Where/OrderBy: The swapping can lock up if it requires that the giver
+            // still stay on more. Instead, we require that the gap between them be smaller instead, and
+            // prioritize the shifts that decrease the gap the most
             List<CallShiftType> swappable = shiftCount
                 .Where(kvp => kvp.Value > 0)
                 .Select(kvp => kvp.Key)
                 .Intersect(receiverShiftTypes)
-                .Where(s => giverHour - s.GetHours() > receiverHour)
+                .Where(s => Math.Abs(giverHour - s.GetHours() - (receiverHour + s.GetHours()))
+                            < Math.Abs(giverHour - receiverHour))
+                .OrderBy(s => Math.Abs(giverHour - s.GetHours() - (receiverHour + s.GetHours())))
                 .ToList();
 
             if (swappable.Count == 0)
@@ -1139,9 +1126,13 @@ public class AlgorithmService
         IEnumerable<CallShiftType> giverShiftTypes = giverShiftCount
             .Where(kvp => kvp.Value > 0).Select(kvp => kvp.Key);
         List<CallShiftType> swappableShiftTypes = giverShiftTypes.Intersect(receiverShiftTypes).ToList();
+        int finalGiverHour = finalGiverYear == 1
+            ? pgy1WorkTime[normalizedGiverIndex]
+            : pgy2WorkTime[normalizedGiverIndex];
 
-        int shiftIndex = rand.Next(0, swappableShiftTypes.Count);
-        CallShiftType shift = swappableShiftTypes[shiftIndex];
+        CallShiftType shift = swappableShiftTypes
+            .OrderBy(s => Math.Abs(finalGiverHour - s.GetHours() - (receiverHour + s.GetHours())))
+            .First();
 
         giverShiftCount[shift]--;
         receiverShiftCount.TryAdd(shift, 0);
@@ -1473,7 +1464,8 @@ public class AlgorithmService
                     _logger.LogDebug(sb.ToString());
                 }
 
-                /*Console.WriteLine("[ERROR] Not able to make valid assignment based on parameters");*/
+                _logger.LogDebug("Flow failed at tryCount {tryCount}: Max: {max}, Min: {min}, Flow: {flow}/{total}",
+                   tryCount, max, min, flow, dayList.Count);
                 continue;
             }
 

--- a/backend/Attributes/CallShiftAttribute.cs
+++ b/backend/Attributes/CallShiftAttribute.cs
@@ -8,6 +8,7 @@ public class CallShiftAttribute : Attribute
 {
     public required int Hours { get; init; }
     public required CallLengthType CallLengthType { get; init; }
+    public PartOfDay PartsOfDay { get; init; } = PartOfDay.Morning | PartOfDay.Afternoon;
     public int RequiredPgy { get; init; } = 0;
     public DayOfWeek[]? ApplicableDays { get; init; } = null;
     public CallShiftRule DateRule { get; init; } = CallShiftRule.None;

--- a/backend/Enums/CallShiftRule.cs
+++ b/backend/Enums/CallShiftRule.cs
@@ -5,6 +5,7 @@ public enum CallShiftRule
     None,
     Weekday,
     FirstSaturdayOfJuly,
+    SundayInTraining,
     JulyFourth,
     LaborDay,
     Thanksgiving,

--- a/backend/Enums/CallShiftType.cs
+++ b/backend/Enums/CallShiftType.cs
@@ -18,7 +18,7 @@ public enum CallShiftType
     [Display(Name = "Saturday (12h)")]
     SaturdayHalfCall = 2,
 
-    [CallShift(Hours = 12, CallLengthType = CallLengthType.Long, ApplicableDays = [DayOfWeek.Sunday])]
+    [CallShift(Hours = 12, CallLengthType = CallLengthType.Long, RequiredPgy = 2, ApplicableDays = [DayOfWeek.Sunday])]
     [Display(Name = "Sunday (12h)")]
     SundayHalfCall = 3,
 

--- a/backend/Enums/CallShiftType.cs
+++ b/backend/Enums/CallShiftType.cs
@@ -59,6 +59,11 @@ public enum CallShiftType
     [Display(Name = "Memorial Day (12h)")]
     MemorialDay = 12,
 
+    // PGY1s in training need to do a Sunday shift, but they aren't allowed Sunday shifts outside...
+    [CallShift(Hours = 12, CallLengthType = CallLengthType.Long, ApplicableDays = [DayOfWeek.Sunday], DateRule = CallShiftRule.SundayInTraining, Priority = 5)]
+    [Display(Name = "Sunday (12h)")]
+    SundayTrainingCall = 13,
+
     [Display(Name = "Custom Shift")]
     Custom = 99
 }

--- a/backend/Enums/CallShiftType.cs
+++ b/backend/Enums/CallShiftType.cs
@@ -6,7 +6,7 @@ namespace MedicalDemo.Enums;
 public enum CallShiftType
 {
     // Standard call shift types
-    [CallShift(Hours = 3, CallLengthType = CallLengthType.Short, DateRule = CallShiftRule.Weekday)]
+    [CallShift(Hours = 3, PartsOfDay = PartOfDay.Afternoon, CallLengthType = CallLengthType.Short, DateRule = CallShiftRule.Weekday)]
     [Display(Name = "Short (3h)")]
     WeekdayShortCall = 0,
 

--- a/backend/Enums/PartOfDay.cs
+++ b/backend/Enums/PartOfDay.cs
@@ -1,0 +1,30 @@
+namespace MedicalDemo.Enums;
+
+[Flags]
+public enum PartOfDay
+{
+    Morning = 1,
+    Afternoon = 2
+}
+
+public static class PartOfDayExtensions
+{
+    extension(PartOfDay partOfDay)
+    {
+        public string? DbChar => partOfDay switch
+        {
+            PartOfDay.Morning => "A",
+            PartOfDay.Afternoon => "P",
+            PartOfDay.Morning | PartOfDay.Afternoon => null,
+            _ => throw new ArgumentOutOfRangeException(nameof(partOfDay), partOfDay, null)
+        };
+
+        public static PartOfDay FromDbChar(string? dbChar) => dbChar switch
+        {
+            "A" => PartOfDay.Morning,
+            "P" => PartOfDay.Afternoon,
+            null => PartOfDay.Morning | PartOfDay.Afternoon,
+            _ => throw new ArgumentOutOfRangeException(nameof(dbChar), dbChar, null)
+        };
+    }
+}

--- a/backend/Extensions/CallShiftRuleExtensions.cs
+++ b/backend/Extensions/CallShiftRuleExtensions.cs
@@ -10,6 +10,7 @@ public static class CallShiftRuleExtensions
         CallShiftRule.None => true,
         CallShiftRule.Weekday => date.DayOfWeek is >= DayOfWeek.Monday and <= DayOfWeek.Friday,
         CallShiftRule.FirstSaturdayOfJuly => IsNthWeekdayOfMonth(date, DayOfWeek.Saturday, 7, 1),
+        CallShiftRule.SundayInTraining => date is { Month: 7 or 8, DayOfWeek: DayOfWeek.Sunday },
         CallShiftRule.JulyFourth => date is { Month: 7, Day: 4 },
         CallShiftRule.LaborDay => IsNthWeekdayOfMonth(date, DayOfWeek.Monday, 9, 1),
         CallShiftRule.Thanksgiving => IsNthWeekdayOfMonth(date, DayOfWeek.Thursday, 11, 4),

--- a/backend/Extensions/CallShiftTypeExtensions.cs
+++ b/backend/Extensions/CallShiftTypeExtensions.cs
@@ -67,4 +67,6 @@ public static class CallShiftTypeExtensions
     public static int GetHours(this CallShiftType shift) => shift.Attr().Hours;
 
     public static CallLengthType GetLengthType(this CallShiftType shift) => shift.Attr().CallLengthType;
+
+    public static PartOfDay GetPartsOfDay(this CallShiftType shift) => shift.Attr().PartsOfDay;
 }

--- a/backend/Models/DTO/Scheduling/Pgy1Dto.cs
+++ b/backend/Models/DTO/Scheduling/Pgy1Dto.cs
@@ -10,18 +10,18 @@ public class Pgy1Dto : ResidentDto
 
     public override bool CanWork(DateOnly curDay)
     {
-        if (IsVacation(curDay) || CommitedWorkDay(curDay))
-        {
-            return false;
-        }
-
-        // Back to back check
         if (CallShiftTypeExtensions.GetAlgorithmCallShiftTypeForDate(curDay, Pgy) is not
             { } shiftType)
         {
             return false;
         }
 
+        if (IsVacation(curDay, shiftType.GetPartsOfDay()) || CommitedWorkDay(curDay))
+        {
+            return false;
+        }
+
+        // Back to back check
         if (IsBackToBackShift(curDay) || IsInARowShift(curDay, shiftType))
         {
             return false;

--- a/backend/Models/DTO/Scheduling/Pgy1Dto.cs
+++ b/backend/Models/DTO/Scheduling/Pgy1Dto.cs
@@ -1,61 +1,36 @@
 using MedicalDemo.Enums;
+using MedicalDemo.Extensions;
 
 namespace MedicalDemo.Models.DTO.Scheduling;
 
 public class Pgy1Dto : ResidentDto
 {
+    public override int Pgy { get; protected set; } = 1;
     public DateOnly LastTrainingDate { get; set; }
 
-    public override bool CanWork(DateOnly curDay, CallLengthType lengthType)
+    public override bool CanWork(DateOnly curDay)
     {
         if (IsVacation(curDay) || CommitedWorkDay(curDay))
         {
             return false;
         }
 
-        int monthIndex = (curDay.Month + 5) % 12;
-        HospitalRole? role = RolePerMonth[monthIndex];
-
-        if (lengthType == CallLengthType.Long)
+        // Back to back check
+        if (CallShiftTypeExtensions.GetAlgorithmCallShiftTypeForDate(curDay, Pgy) is not
+            { } shiftType)
         {
-            if (curDay.Month is 7 or 8 && role is { DoesTrainingLong: false } ||
-                curDay.Month is not 7 and not 8 && role is { DoesLong: false })
-            {
-                return false;
-            }
-
-            DateOnly prevDay = curDay.AddDays(-1);
-            DateOnly nextDay = curDay.AddDays(1);
-            if (IsWorking(prevDay)
-                || CommitedWorkDay(nextDay)
-                || IsWorking(nextDay)
-                || CommitedWorkDay(prevDay))
-            {
-                return false;
-            }
+            return false;
         }
-        else // Weekday
+
+        if (IsBackToBackShift(curDay) || IsInARowShift(curDay, shiftType))
         {
-            if (curDay.Month is 7 or 8 && role is { DoesTrainingShort: false } ||
-                curDay.Month is not 7 and not 8 && role is { DoesShort: false })
-            {
-                return false;
-            }
+            return false;
+        }
 
-            DateOnly nextDay = curDay.AddDays(1);
-            DateOnly prevDay = curDay.AddDays(-1);
-
-            if ((IsWorking(nextDay) || CommitedWorkDay(nextDay)) &&
-                nextDay.DayOfWeek == DayOfWeek.Saturday)
-            {
-                return false;
-            }
-
-            if ((IsWorking(prevDay) || CommitedWorkDay(prevDay)) &&
-                prevDay.DayOfWeek == DayOfWeek.Sunday)
-            {
-                return false;
-            }
+        // Rotation check
+        if (!DoesRotationAllow(curDay, shiftType.GetLengthType()))
+        {
+            return false;
         }
 
         if (curDay <= LastTrainingDate)

--- a/backend/Models/DTO/Scheduling/Pgy2Dto.cs
+++ b/backend/Models/DTO/Scheduling/Pgy2Dto.cs
@@ -8,7 +8,13 @@ public class Pgy2Dto : ResidentDto
     public override int Pgy { get; protected set; } = 2;
     public override bool CanWork(DateOnly curDay)
     {
-        if (IsVacation(curDay) || CommitedWorkDay(curDay))
+        if (CallShiftTypeExtensions.GetAlgorithmCallShiftTypeForDate(curDay, Pgy) is not
+            { } shiftType)
+        {
+            return false;
+        }
+
+        if (IsVacation(curDay, shiftType.GetPartsOfDay()) || CommitedWorkDay(curDay))
         {
             return false;
         }
@@ -17,11 +23,6 @@ public class Pgy2Dto : ResidentDto
         HospitalRole? role = RolePerMonth[monthIndex];
 
         // Back to back check
-        if (CallShiftTypeExtensions.GetAlgorithmCallShiftTypeForDate(curDay, Pgy) is not
-            { } shiftType)
-        {
-            return false;
-        }
         if (IsBackToBackShift(curDay) || IsInARowShift(curDay, shiftType))
         {
             return false;

--- a/backend/Models/DTO/Scheduling/Pgy2Dto.cs
+++ b/backend/Models/DTO/Scheduling/Pgy2Dto.cs
@@ -19,9 +19,6 @@ public class Pgy2Dto : ResidentDto
             return false;
         }
 
-        int monthIndex = (curDay.Month + 5) % 12;
-        HospitalRole? role = RolePerMonth[monthIndex];
-
         // Back to back check
         if (IsBackToBackShift(curDay) || IsInARowShift(curDay, shiftType))
         {

--- a/backend/Models/DTO/Scheduling/Pgy2Dto.cs
+++ b/backend/Models/DTO/Scheduling/Pgy2Dto.cs
@@ -1,10 +1,12 @@
 using MedicalDemo.Enums;
+using MedicalDemo.Extensions;
 
 namespace MedicalDemo.Models.DTO.Scheduling;
 
 public class Pgy2Dto : ResidentDto
 {
-    public override bool CanWork(DateOnly curDay, CallLengthType lengthType)
+    public override int Pgy { get; protected set; } = 2;
+    public override bool CanWork(DateOnly curDay)
     {
         if (IsVacation(curDay) || CommitedWorkDay(curDay))
         {
@@ -14,46 +16,21 @@ public class Pgy2Dto : ResidentDto
         int monthIndex = (curDay.Month + 5) % 12;
         HospitalRole? role = RolePerMonth[monthIndex];
 
-        if (lengthType == CallLengthType.Long)
+        // Back to back check
+        if (CallShiftTypeExtensions.GetAlgorithmCallShiftTypeForDate(curDay, Pgy) is not
+            { } shiftType)
         {
-            if (curDay.Month is 7 or 8 && role is { DoesTrainingLong: false } ||
-                curDay.Month is not 7 and not 8 && role is { DoesLong: false })
-            {
-                return false;
-            }
-
-            DateOnly prevDay = curDay.AddDays(-1);
-            DateOnly nextDay = curDay.AddDays(1);
-            if (IsWorking(prevDay)
-                || CommitedWorkDay(nextDay)
-                || IsWorking(nextDay)
-                || CommitedWorkDay(prevDay))
-            {
-                return false;
-            }
+            return false;
         }
-        else // Weekday
+        if (IsBackToBackShift(curDay) || IsInARowShift(curDay, shiftType))
         {
-            if (curDay.Month is 7 or 8 && role is { DoesTrainingShort: false } ||
-                curDay.Month is not 7 and not 8 && role is { DoesShort: false })
-            {
-                return false;
-            }
+            return false;
+        }
 
-            DateOnly nextDay = curDay.AddDays(1);
-            DateOnly prevDay = curDay.AddDays(-1);
-
-            if ((IsWorking(nextDay) || CommitedWorkDay(nextDay)) &&
-                nextDay.DayOfWeek == DayOfWeek.Saturday)
-            {
-                return false;
-            }
-
-            if ((IsWorking(prevDay) || CommitedWorkDay(prevDay)) &&
-                prevDay.DayOfWeek == DayOfWeek.Sunday)
-            {
-                return false;
-            }
+        // Rotation check
+        if (!DoesRotationAllow(curDay, shiftType.GetLengthType()))
+        {
+            return false;
         }
 
         return true;

--- a/backend/Models/DTO/Scheduling/Pgy3Dto.cs
+++ b/backend/Models/DTO/Scheduling/Pgy3Dto.cs
@@ -1,44 +1,29 @@
 using MedicalDemo.Enums;
+using MedicalDemo.Extensions;
 
 namespace MedicalDemo.Models.DTO.Scheduling;
 
 public class Pgy3Dto : ResidentDto
 {
-    public override bool CanWork(DateOnly curDay, CallLengthType lengthType)
+    public override int Pgy { get; protected set; } = 3;
+
+    public override bool CanWork(DateOnly curDay)
     {
         if (IsVacation(curDay) || CommitedWorkDay(curDay))
         {
             return false;
         }
 
-        if (lengthType == CallLengthType.Long)
+        // Back to back check
+        if (CallShiftTypeExtensions.GetAlgorithmCallShiftTypeForDate(curDay, Pgy) is not
+            { } shiftType)
         {
-            DateOnly prevDay = curDay.AddDays(-1);
-            DateOnly nextDay = curDay.AddDays(1);
-            if (IsWorking(prevDay)
-                || CommitedWorkDay(nextDay)
-                || IsWorking(nextDay)
-                || CommitedWorkDay(prevDay))
-            {
-                return false;
-            }
+            return false;
         }
-        else // Weekday
+
+        if (IsBackToBackShift(curDay) || IsInARowShift(curDay, shiftType))
         {
-            DateOnly nextDay = curDay.AddDays(1);
-            DateOnly prevDay = curDay.AddDays(-1);
-
-            if ((IsWorking(nextDay) || CommitedWorkDay(nextDay)) &&
-                nextDay.DayOfWeek == DayOfWeek.Saturday)
-            {
-                return false;
-            }
-
-            if ((IsWorking(prevDay) || CommitedWorkDay(prevDay)) &&
-                prevDay.DayOfWeek == DayOfWeek.Sunday)
-            {
-                return false;
-            }
+            return false;
         }
 
         return true;

--- a/backend/Models/DTO/Scheduling/Pgy3Dto.cs
+++ b/backend/Models/DTO/Scheduling/Pgy3Dto.cs
@@ -9,18 +9,18 @@ public class Pgy3Dto : ResidentDto
 
     public override bool CanWork(DateOnly curDay)
     {
-        if (IsVacation(curDay) || CommitedWorkDay(curDay))
-        {
-            return false;
-        }
-
-        // Back to back check
         if (CallShiftTypeExtensions.GetAlgorithmCallShiftTypeForDate(curDay, Pgy) is not
             { } shiftType)
         {
             return false;
         }
 
+        if (IsVacation(curDay, shiftType.GetPartsOfDay()) || CommitedWorkDay(curDay))
+        {
+            return false;
+        }
+
+        // Back to back check
         if (IsBackToBackShift(curDay) || IsInARowShift(curDay, shiftType))
         {
             return false;

--- a/backend/Models/DTO/Scheduling/ResidentDto.cs
+++ b/backend/Models/DTO/Scheduling/ResidentDto.cs
@@ -9,7 +9,8 @@ public abstract class ResidentDto
     public string Name { get; set; }
     public abstract int Pgy { get; protected set; }
     public bool InTraining { get; set; }
-    public HashSet<DateOnly> VacationRequests { get; set; } = new();
+    public HashSet<DateOnly> MorningVacationRequests { get; set; } = new();
+    public HashSet<DateOnly> AfternoonVacationRequests { get; set; } = new();
     public HashSet<DateOnly> WorkDays { get; set; } = new();
     public HashSet<DateOnly> CommitedWorkDays { get; set; } = new();
     public HashSet<DateOnly> PendingSaveWorkDays { get; set; } = new();
@@ -51,9 +52,29 @@ public abstract class ResidentDto
             : new DateOnly(9999, 12, 31);
     }
 
-    public bool IsVacation(DateOnly curDay)
+    public bool IsMorningVacation(DateOnly curDay)
     {
-        return VacationRequests.Contains(curDay);
+        return MorningVacationRequests.Contains(curDay);
+    }
+
+    public bool IsAfternoonVacation(DateOnly curDay)
+    {
+        return AfternoonVacationRequests.Contains(curDay);
+    }
+
+    public bool IsVacation(DateOnly date, PartOfDay partOfDay)
+    {
+        if (partOfDay.HasFlag(PartOfDay.Morning) && IsMorningVacation(date))
+        {
+            return true;
+        }
+
+        if (partOfDay.HasFlag(PartOfDay.Afternoon) && IsAfternoonVacation(date))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     public bool IsWorking(DateOnly curDay)

--- a/backend/Models/DTO/Scheduling/ResidentDto.cs
+++ b/backend/Models/DTO/Scheduling/ResidentDto.cs
@@ -1,4 +1,5 @@
 using MedicalDemo.Enums;
+using MedicalDemo.Extensions;
 
 namespace MedicalDemo.Models.DTO.Scheduling;
 
@@ -6,6 +7,7 @@ public abstract class ResidentDto
 {
     public string ResidentId { get; set; }
     public string Name { get; set; }
+    public abstract int Pgy { get; protected set; }
     public bool InTraining { get; set; }
     public HashSet<DateOnly> VacationRequests { get; set; } = new();
     public HashSet<DateOnly> WorkDays { get; set; } = new();
@@ -15,7 +17,7 @@ public abstract class ResidentDto
 
     public HospitalRole?[] RolePerMonth { get; set; } = new HospitalRole?[12];
 
-    public abstract bool CanWork(DateOnly date, CallLengthType lengthType);
+    public abstract bool CanWork(DateOnly date);
     public abstract void AddWorkDay(DateOnly date);
     public abstract void RemoveWorkDay(DateOnly date);
 
@@ -59,9 +61,76 @@ public abstract class ResidentDto
         return WorkDays.Contains(curDay);
     }
 
-    public bool CanAddWorkDay(DateOnly curDay, CallLengthType lengthType)
+    public bool CanAddWorkDay(DateOnly curDay)
     {
-        return CanWork(curDay, lengthType) && !IsWorking(curDay);
+        return CanWork(curDay) && !IsWorking(curDay);
+    }
+
+    protected bool IsBackToBackShift(DateOnly date)
+    {
+        DateOnly prevDay = date.AddDays(-1);
+        DateOnly nextDay = date.AddDays(1);
+
+        return IsWorking(prevDay) || CommitedWorkDay(nextDay) || IsWorking(nextDay) || CommitedWorkDay(prevDay);
+    }
+
+    protected bool IsInARowShift(DateOnly date, CallShiftType type)
+    {
+        // Walk backwards at most a week
+        DateOnly until = date.AddDays(-7);
+        for (DateOnly processing = date.AddDays(-1); processing >= until; processing = processing.AddDays(-1))
+        {
+            CallShiftType? processingType = CallShiftTypeExtensions.GetAlgorithmCallShiftTypeForDate(processing, Pgy);
+            if (processingType == type)
+            {
+                if (IsWorking(processing) || CommitedWorkDay(processing))
+                {
+                    return true;
+                }
+
+                break;
+            }
+        }
+
+        until = date.AddDays(7);
+        for (DateOnly processing = date.AddDays(1); processing <= until; processing = processing.AddDays(1))
+        {
+            CallShiftType? processingType = CallShiftTypeExtensions.GetAlgorithmCallShiftTypeForDate(processing, Pgy);
+            if (processingType == type)
+            {
+                if (IsWorking(processing) || CommitedWorkDay(processing))
+                {
+                    return true;
+                }
+
+                break;
+            }
+        }
+
+        return false;
+    }
+
+    protected bool DoesRotationAllow(DateOnly date, CallLengthType lengthType)
+    {
+        HospitalRole role = GetHospitalRoleForCalendarMonth(date.Month);
+        if (lengthType == CallLengthType.Long)
+        {
+            if (date.Month is 7 or 8 && role is { DoesTrainingLong: false } ||
+                date.Month is not 7 and not 8 && role is { DoesLong: false })
+            {
+                return false;
+            }
+        }
+        else // Weekday
+        {
+            if (date.Month is 7 or 8 && role is { DoesTrainingShort: false } ||
+                date.Month is not 7 and not 8 && role is { DoesShort: false })
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/backend/Services/DatabaseSeeder.cs
+++ b/backend/Services/DatabaseSeeder.cs
@@ -1,3 +1,4 @@
+using MedicalDemo.Enums;
 using MedicalDemo.Models;
 using MedicalDemo.Models.Entities;
 using Microsoft.EntityFrameworkCore;
@@ -460,9 +461,9 @@ public class DatabaseSeeder
                         GroupId = Guid.NewGuid().ToString(),
                         HalfDay = Random.Shared.Next(0, 3) switch
                         {
-                            0 => null,
-                            1 => "A",
-                            2 => "P",
+                            0 => (PartOfDay.Morning | PartOfDay.Afternoon).DbChar,
+                            1 => PartOfDay.Morning.DbChar,
+                            2 => PartOfDay.Afternoon.DbChar,
                         },
                         ResidentId = residents[Random.Shared.Next(0, residents.Count)].ResidentId,
                         Status = "Approved",

--- a/backend/Services/SchedulingMapperService.cs
+++ b/backend/Services/SchedulingMapperService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using MedicalDemo.Enums;
 using MedicalDemo.Models;
 using MedicalDemo.Models.DTO.Scheduling;
 using MedicalDemo.Models.Entities;
@@ -23,12 +24,13 @@ public class SchedulingMapperService
             .Select(d => d.ShiftDate)
             .ToList();
 
-        Pgy1Dto dto = new Pgy1Dto
+        Dictionary<PartOfDay, List<DateOnly>> days = BuildVacations(vacations);
+        Pgy1Dto dto = new()
         {
             ResidentId = resident.ResidentId,
             Name = resident.FirstName + " " + resident.LastName,
-            VacationRequests
-                = [.. vacations.Select(v => v.Date)],
+            MorningVacationRequests = [.. days[PartOfDay.Morning]],
+            AfternoonVacationRequests = [.. days[PartOfDay.Afternoon]],
             CommitedWorkDays = [.. committedDates],
             InTraining = resident.GraduateYr == 1
         };
@@ -50,12 +52,13 @@ public class SchedulingMapperService
             .Select(d => d.ShiftDate)
             .ToList();
 
+        Dictionary<PartOfDay, List<DateOnly>> days = BuildVacations(vacations);
         Pgy2Dto dto = new()
         {
             ResidentId = resident.ResidentId,
             Name = resident.FirstName + " " + resident.LastName,
-            VacationRequests
-                = [.. vacations.Select(v => v.Date)],
+            MorningVacationRequests = [.. days[PartOfDay.Morning]],
+            AfternoonVacationRequests = [.. days[PartOfDay.Afternoon]],
             CommitedWorkDays = [.. committedDates],
             InTraining = resident.GraduateYr == 2
         };
@@ -76,13 +79,38 @@ public class SchedulingMapperService
             .Select(d => d.ShiftDate)
             .ToList();
 
+        Dictionary<PartOfDay, List<DateOnly>> days = BuildVacations(vacations);
         return new Pgy3Dto
         {
             ResidentId = resident.ResidentId,
             Name = resident.FirstName + " " + resident.LastName,
-            VacationRequests
-                = [.. vacations.Select(v => v.Date)],
+            MorningVacationRequests = [.. days[PartOfDay.Morning]],
+            AfternoonVacationRequests = [.. days[PartOfDay.Afternoon]],
             CommitedWorkDays = [.. committedDates]
         };
+    }
+
+    private Dictionary<PartOfDay, List<DateOnly>> BuildVacations(IEnumerable<Vacation> vacations)
+    {
+        Dictionary<PartOfDay, List<DateOnly>> days = new() {
+            { PartOfDay.Morning, []},
+            { PartOfDay.Afternoon, []},
+        };
+
+        foreach (Vacation vacation in vacations)
+        {
+            PartOfDay part = PartOfDay.FromDbChar(vacation.HalfDay);
+            if (part.HasFlag(PartOfDay.Morning))
+            {
+                days[PartOfDay.Morning].Add(vacation.Date);
+            }
+
+            if (part.HasFlag(PartOfDay.Afternoon))
+            {
+                days[PartOfDay.Afternoon].Add(vacation.Date);
+            }
+        }
+
+        return days;
     }
 }


### PR DESCRIPTION
This PR addresses PSY-123 (algorithm feedback) and PSY-97 (implementing half-days into algorithm)

Algorithm Feedback
- Sunday calls require a PGY of 2
- Sunday training calls have a specific exception for July and August
- Back-to-back shifts are no longer allowed (in any capacity)
- In-a-row shifts are no longer allowed (cannot work shift X if last time or next time shift X occurs, it was worked)

Other improvements
- InitialShiftAssignment chooses a PGY year now with a random weighted die, according to group hours
- InitialShiftAssignment chooses a resident from a PGY year now with a random weighted die, according to resident hours within group
- Swapping no longer prevents giver and receiver crossing over each other; instead, it only requires that the hour gap between them becomes smaller. It prioritizes the swappable shifts that decrease the gap the most.

Vacations
- Vacations are separted into morning and afternoon (into both buckets if a full day vacation), and Call Shifts now specify what parts of day they operate during