### PR TITLE
Psy 100 psy 104 update frontend for new is read column

### DIFF
--- a/backend/Controllers/SwapRequestsController.cs
+++ b/backend/Controllers/SwapRequestsController.cs
@@ -123,10 +123,9 @@ public class SwapRequestsController : ControllerBase
     public async Task<IActionResult> DeleteAllSwapRequests(
         [FromBody] List<Guid> swapRequestIds)
     {
-        // Fetch all swap requests that are Approved/Denied status
+        // Fetch all swap requests
         List<SwapRequest> swapRequestsToDelete = await _context.SwapRequests
-            .Where(s => swapRequestIds.Contains(s.SwapRequestId) &&
-                    (s.Status == RequestStatus.Approved || s.Status == RequestStatus.Denied))
+            .Where(s => swapRequestIds.Contains(s.SwapRequestId))
         .ToListAsync();
 
         // Find which IDs were not found (don't exist/pending status)

--- a/backend/Controllers/SwapRequestsController.cs
+++ b/backend/Controllers/SwapRequestsController.cs
@@ -123,9 +123,9 @@ public class SwapRequestsController : ControllerBase
     public async Task<IActionResult> DeleteAllSwapRequests(
         [FromBody] List<Guid> swapRequestIds)
     {
-        // Fetch all swap requests
+        // Fetch all swap requests that are marked as read
         List<SwapRequest> swapRequestsToDelete = await _context.SwapRequests
-            .Where(s => swapRequestIds.Contains(s.SwapRequestId))
+            .Where(s => swapRequestIds.Contains(s.SwapRequestId) && s.IsRead)
         .ToListAsync();
 
         // Find which IDs were not found (don't exist/pending status)

--- a/frontend/src/app/dashboard/components/AdminPage.tsx
+++ b/frontend/src/app/dashboard/components/AdminPage.tsx
@@ -272,9 +272,17 @@ const SwapHistoryTab: React.FC<SwapHistoryTabProps> = ({ idToName, onPendingCoun
     }
   }
 
+  const sortSwaps = (swaps: typeof swapHistory) =>
+    [...swaps].sort((a, b) => {
+      const pendingA = a.status.id === 0 ? 0 : 1;
+      const pendingB = b.status.id === 0 ? 0 : 1;
+      if (pendingA !== pendingB) return pendingA - pendingB;
+      return new Date(a.requesterDate || "").getTime() - new Date(b.requesterDate || "").getTime();
+    });
+
   const orderedSwapHistory = [
-    ...swapHistory.filter((swap) => !swap.isRead),
-    ...swapHistory.filter((swap) => swap.isRead),
+    ...sortSwaps(swapHistory.filter((swap) => !swap.isRead)),
+    ...sortSwaps(swapHistory.filter((swap) => swap.isRead)),
   ];
 
   return (
@@ -301,12 +309,13 @@ const SwapHistoryTab: React.FC<SwapHistoryTabProps> = ({ idToName, onPendingCoun
               <th className="px-1 sm:px-3 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Partner</th>
               <th className="px-1 sm:px-3 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Details</th>
               <th className="px-1 sm:px-3 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+              <th className="px-1 sm:px-3 py-2 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200 dark:bg-neutral-900 dark:divide-gray-700">
             {loading ? (
               <tr>
-                <td colSpan={6} className="px-6 py-4 text-center text-gray-400 italic">Loading...</td>
+                <td colSpan={7} className="px-6 py-4 text-center text-gray-400 italic">Loading...</td>
               </tr>
             ) : orderedSwapHistory.length > 0 ? (
                 orderedSwapHistory.map((swap, idx) => (
@@ -323,32 +332,26 @@ const SwapHistoryTab: React.FC<SwapHistoryTabProps> = ({ idToName, onPendingCoun
                     <td className={`px-1 sm:px-1 py-3 sm:py-4 whitespace-nowrap text-sm font-semibold ${
                       swap.status.id === 1 ? 'text-green-600' : swap.status.id === 2 ? 'text-red-600' : 'text-yellow-600'
                       }`}>
-                      <div className="flex items-center justify-between w-full">
-                        {`${swap.status.description} `}
-                        {!swap.isRead ? (
-                          <>
-                            <Button variant="outline" size="sm" className="mr-2 text-blue-600 border-blue-600 hover:bg-blue-500 hover:text-white cursor-pointer" onClick={() => {
-                              if (swap.status.id === 0) {
-                                handleWarnMarkAsRead(swap.swapRequestId)
-                              } else {
-                                handleMarkAsRead(swap.swapRequestId)
-                              }
-                            }}>
-                              <Check className="h-3 w-3 mr-1" /> Mark as Read
-                            </Button>
-                          </>
-                        ) : (
-                          <Button variant="outline" size="sm" className="mr-2 text-slate-600 hover:text-slate-600 border-slate-600" onClick={() => (/*Possible future implementation of marking as unread*/ "")}>
-                            Read
-                          </Button>
-                        )}
-                      </div>
+                      {`${swap.status.description}`}
+                    </td>
+                    <td className="px-1 sm:px-3 py-3 sm:py-4 whitespace-nowrap text-sm">
+                      {!swap.isRead ? (
+                        <Button className="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md border border-blue-600 text-blue-600 hover:bg-blue-500 hover:text-white bg-transparent shadow-none cursor-pointer" onClick={() => {
+                          if (swap.status.id === 0) {
+                            handleWarnMarkAsRead(swap.swapRequestId)
+                          } else {
+                            handleMarkAsRead(swap.swapRequestId)
+                          }
+                        }}>
+                          <Check className="h-3 w-3 mr-1" /> Mark as Read
+                        </Button>
+                      ) : null}
                     </td>
                   </tr>
                 ))
               ) : (
                 <tr>
-                  <td colSpan={6} className="px-6 py-4 text-center text-gray-500 italic">No swap call history found.</td>
+                  <td colSpan={7} className="px-6 py-4 text-center text-gray-500 italic">No swap call history found.</td>
                 </tr>
             )}
           </tbody>
@@ -414,9 +417,12 @@ function groupRequests(requests: Request[]) {
     });
   }
 
-  result.sort((a, b) =>
-    new Date(a.startDate || "").getTime() - new Date(b.startDate || "").getTime()
-  );
+  result.sort((a, b) => {
+    const pendingA = a.status === "Pending" ? 0 : 1;
+    const pendingB = b.status === "Pending" ? 0 : 1;
+    if (pendingA !== pendingB) return pendingA - pendingB;
+    return new Date(a.startDate || "").getTime() - new Date(b.startDate || "").getTime();
+  });
   return result;
 }
 
@@ -535,7 +541,7 @@ const VacationRequestsTab: React.FC<VacationRequestsTabProps> = ({ handleApprove
         ) : groupedRequests.length > 0 ? (
           groupedRequests.map((request: Request, idx: number) => (
             <tr key={request.id || `${request.startDate || request.date || ''}-${getResidentName(request)}-${idx}`}
-              className="hover:bg-gray-50 dark:hover:bg-neutral-800">
+              className={`${request.status === 'Pending' ? 'bg-yellow-50 dark:bg-yellow-900/20 hover:bg-yellow-100 dark:hover:bg-yellow-900/40' : 'hover:bg-gray-50 dark:hover:bg-neutral-800'}`}>
               <td className="px-2 sm:px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">{getRequestDate(request)}</td>
               <td className="px-2 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{getResidentName(request)}</td>
               <td className="px-2 sm:px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">

--- a/frontend/src/app/dashboard/components/AdminPage.tsx
+++ b/frontend/src/app/dashboard/components/AdminPage.tsx
@@ -57,6 +57,7 @@ interface SwapRequest {
   status: SwapRequestStatus;
   createdAt: string;
   updatedAt: string;
+  isRead: boolean;
   details?: string;
 }
 
@@ -179,9 +180,91 @@ const SwapHistoryTab: React.FC<SwapHistoryTabProps> = ({ idToName, onPendingCoun
       .finally(() => setLoading(false));
   }, [onPendingCountChange]);
 
+  const handleClearReadSwaps = async () => {
+    /*const vacationIds = requests.map(r => r.id);
+    if (vacationIds.length === 0) {
+      toast({ title: 'No requests to clear', description: 'There are no vacation requests to delete.' });
+      return;
+    }
+    try {
+      const response = await fetch(`${config.apiUrl}/api/vacations`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(vacationIds),
+      });
+      if (response.ok) {
+        const result = await response.json();
+        if (result.notDeleted && result.notDeleted.length > 0) {
+          toast({
+            title: 'Partial success',
+            description: `${vacationIds.length - result.notDeleted.length} requests cleared. ${result.notDeleted.length} failed to delete.`,
+            variant: 'destructive',
+          });
+        } else {
+          toast({ title: 'Success', description: 'All vacation requests have been cleared.' });
+        }
+        fetchVacations();
+      } else {
+        toast({ title: 'Error', description: 'Failed to clear vacation requests.', variant: 'destructive' });
+      }
+    } catch {
+      toast({ title: 'Error', description: 'An error occurred while clearing requests.', variant: 'destructive' });
+    }*/
+  };
+
+  const handleMarkAsRead = async (swapId: string) => {
+    try {
+      const response = await fetch(`${config.apiUrl}/api/SwapRequests/${swapId}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          isRead: true,
+        }),
+      });
+
+      if (!response.ok) {
+        const error = await response.text();
+        throw new Error(error || "Failed to mark swap request as read.");
+      }
+
+      setSwapHistory((prev) =>
+        prev.map((swap) =>
+          swap.swapRequestId === swapId
+            ? { ...swap, isRead: true }
+            : swap
+        )
+      );
+    } catch (err) {
+      console.error("Error marking swap as read:", err);
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: err instanceof Error ? err.message : "Failed to mark as read.",
+      });
+    }
+  }
+
+  const orderedSwapHistory = [
+    ...swapHistory.filter((swap) => !swap.isRead),
+    ...swapHistory.filter((swap) => swap.isRead),
+  ];
+
   return (
     <Card className="p-4 sm:p-6 lg:p-8 bg-gray-50 dark:bg-neutral-900 shadow-lg rounded-2xl w-full flex flex-col gap-4 mb-6 sm:mb-8 border border-gray-200 dark:border-gray-800">
-      <h2 className="text-lg sm:text-xl font-bold mb-4">Swap Call History</h2>
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-4 gap-2">
+        <h2 className="text-lg sm:text-xl font-bold mb-4">Swap Call History</h2>
+        <ConfirmDialog
+          triggerText={<><X className="h-4 w-4" /><span>Clear</span></>}
+          title="Clear all read swap requests?"
+          message="Requests not marked as READ will not be cleared. This action cannot be undone."
+          confirmText="Clear"
+          cancelText="Cancel"
+          onConfirm={handleClearReadSwaps}
+          variant="danger"
+          />
+      </div>
       <div className="overflow-x-auto max-h-96 overflow-y-auto w-full">
         <table className="w-full divide-y divide-gray-200 dark:divide-gray-700">
           <thead className="bg-gray-100 dark:bg-neutral-800">
@@ -199,29 +282,40 @@ const SwapHistoryTab: React.FC<SwapHistoryTabProps> = ({ idToName, onPendingCoun
               <tr>
                 <td colSpan={6} className="px-6 py-4 text-center text-gray-400 italic">Loading...</td>
               </tr>
-            ) : swapHistory.length > 0 ? (
-              swapHistory.map((swap, idx) => (
-                <tr key={swap.swapRequestId || idx} className="hover:bg-gray-50 dark:hover:bg-neutral-800">
-                  <td className="px-1 sm:px-3 py-3 sm:py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{swap.requesterDate ? formatDate(swap.requesterDate) : ''}</td>
-                  <td className="px-1 sm:px-3 py-3 sm:py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
-                    {idToName[swap.requesterId] || `Resident ${swap.requesterId}`}
-                  </td>
-                  <td className="px-1 sm:px-3 py-3 sm:py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
-                    {idToName[swap.requesteeId] || `Resident ${swap.requesteeId}`}
-                  </td>
-                  <td className="px-1 sm:px-3 py-3 sm:py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{swap.requesteeDate ? formatDate(swap.requesteeDate) : ''}</td>
-                  <td className="px-1 sm:px-3 py-3 sm:py-4 text-sm text-gray-500 dark:text-gray-400 max-w-xs break-all">{swap.details || '-'}</td>
-                  <td className={`px-1 sm:px-3 py-3 sm:py-4 whitespace-nowrap text-sm font-semibold ${
-                    swap.status.id === 1 ? 'text-green-600' : swap.status.id === 2 ? 'text-red-600' : 'text-yellow-600'
-                  }`}>
-                    {swap.status.description}
-                  </td>
+            ) : orderedSwapHistory.length > 0 ? (
+                orderedSwapHistory.map((swap, idx) => (
+                  <tr key={swap.swapRequestId || idx} className={`${!swap.isRead ? 'bg-yellow-50 dark:bg-yellow-900/20 hover:bg-yellow-100 dark:hover:bg-yellow-900/40' : 'hover:bg-gray-50 dark:hover:bg-neutral-800'}`}>
+                    <td className="px-1 sm:px-3 py-3 sm:py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{swap.requesterDate ? formatDate(swap.requesterDate) : ''}</td>
+                    <td className="px-1 sm:px-3 py-3 sm:py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                      {idToName[swap.requesterId] || `Resident ${swap.requesterId}`}
+                    </td>
+                    <td className="px-1 sm:px-3 py-3 sm:py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                      {idToName[swap.requesteeId] || `Resident ${swap.requesteeId}`}
+                    </td>
+                    <td className="px-1 sm:px-3 py-3 sm:py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">{swap.requesteeDate ? formatDate(swap.requesteeDate) : ''}</td>
+                    <td className="px-1 sm:px-3 py-3 sm:py-4 text-sm text-gray-500 dark:text-gray-400 max-w-xs break-all">{swap.details || '-'}</td>
+                    <td className={`px-1 sm:px-1 py-3 sm:py-4 whitespace-nowrap text-sm font-semibold ${
+                      swap.status.id === 1 ? 'text-green-600' : swap.status.id === 2 ? 'text-red-600' : 'text-yellow-600'
+                      }`}>
+                      <div className="flex items-center justify-between w-full">
+                        {`${swap.status.description} `}
+                        {!swap.isRead ? (
+                          <Button variant="outline" size="sm" className="mr-2 text-blue-600 border-blue-600 hover:bg-blue-500 hover:text-white cursor-pointer" onClick={() => handleMarkAsRead(swap.swapRequestId) }>
+                            <Check className="h-3 w-3 mr-1" /> Mark as Read
+                          </Button>
+                        ) : (
+                          <Button variant="outline" size="sm" className="mr-2 text-slate-600 hover:text-slate-600 border-slate-600" onClick={() => (/*Possible future implementation of marking as unread*/ "")}>
+                            Read
+                          </Button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={6} className="px-6 py-4 text-center text-gray-500 italic">No swap call history found.</td>
                 </tr>
-              ))
-            ) : (
-              <tr>
-                <td colSpan={6} className="px-6 py-4 text-center text-gray-500 italic">No swap call history found.</td>
-              </tr>
             )}
           </tbody>
         </table>

--- a/frontend/src/app/dashboard/components/AdminPage.tsx
+++ b/frontend/src/app/dashboard/components/AdminPage.tsx
@@ -164,6 +164,7 @@ interface SwapHistoryTabProps {
 const SwapHistoryTab: React.FC<SwapHistoryTabProps> = ({ idToName, onPendingCountChange }) => {
   const [swapHistory, setSwapHistory] = useState<SwapRequest[]>([]);
   const [loading, setLoading] = useState(true);
+  const [warnReadId, setWarnReadId] = useState<string | null>(null);
 
   useEffect(() => {
     setLoading(true);
@@ -232,6 +233,10 @@ const SwapHistoryTab: React.FC<SwapHistoryTabProps> = ({ idToName, onPendingCoun
         variant: "destructive",
       });
     }
+  };
+
+  const handleWarnMarkAsRead = (swapId: string) => {
+    setWarnReadId(swapId);
   };
 
   const handleMarkAsRead = async (swapId: string) => {
@@ -322,9 +327,33 @@ const SwapHistoryTab: React.FC<SwapHistoryTabProps> = ({ idToName, onPendingCoun
                       <div className="flex items-center justify-between w-full">
                         {`${swap.status.description} `}
                         {!swap.isRead ? (
-                          <Button variant="outline" size="sm" className="mr-2 text-blue-600 border-blue-600 hover:bg-blue-500 hover:text-white cursor-pointer" onClick={() => handleMarkAsRead(swap.swapRequestId) }>
-                            <Check className="h-3 w-3 mr-1" /> Mark as Read
-                          </Button>
+                          <>
+                            <Button variant="outline" size="sm" className="mr-2 text-blue-600 border-blue-600 hover:bg-blue-500 hover:text-white cursor-pointer" onClick={() => {
+                              if (swap.status.id === 0) {
+                                handleWarnMarkAsRead(swap.swapRequestId)
+                              } else {
+                                handleMarkAsRead(swap.swapRequestId)
+                              }
+                            }}>
+                              <Check className="h-3 w-3 mr-1" /> Mark as Read
+                            </Button>
+                            <ConfirmDialog
+                              open={!!warnReadId}
+                              onOpenChange={(open) => {
+                                if (!open) setWarnReadId(null);
+                              }}
+                              title="Mark pending request as read?"
+                              message="This swap request is still pending. Marking it as read makes it possible to delete. Mark as read anyway?"
+                              confirmText="Mark as Read"
+                              cancelText="Cancel"
+                              onConfirm={async () => {
+                                if (warnReadId) {
+                                  await handleMarkAsRead(warnReadId);
+                                  setWarnReadId(null);
+                                }
+                              }}
+                              />
+                          </>
                         ) : (
                           <Button variant="outline" size="sm" className="mr-2 text-slate-600 hover:text-slate-600 border-slate-600" onClick={() => (/*Possible future implementation of marking as unread*/ "")}>
                             Read

--- a/frontend/src/app/dashboard/components/AdminPage.tsx
+++ b/frontend/src/app/dashboard/components/AdminPage.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect, useMemo, useCallback } from "react";
 import { Card } from "../../../components/ui/card";
 import { Button } from "../../../components/ui/button";
 import { ConfirmDialog } from "../../../components/ui/confirm-dialog";
-import { CalendarX, Send, Check, X, Shield, Users, Repeat, Search } from "lucide-react";
+import { CalendarX, Send, Check, X, Shield, Users, Repeat, Search, Trash2 } from "lucide-react";
 import { config } from '../../../config';
 import { toast } from "../../../lib/use-toast";
 import { VacationResponse } from "@/lib/models/VacationResponse";
@@ -185,7 +185,7 @@ const SwapHistoryTab: React.FC<SwapHistoryTabProps> = ({ idToName, onPendingCoun
 
     if (readSwapIds.length === 0) {
       toast({
-        title: "No swaps to clear",
+        title: "No swaps to delete",
         description: "There are no read swap requests to delete.",
       });
       return;
@@ -204,13 +204,13 @@ const SwapHistoryTab: React.FC<SwapHistoryTabProps> = ({ idToName, onPendingCoun
         if (result.notDeleted && result.notDeleted.length > 0) {
           toast({
             title: "Partial success",
-            description: `${readSwapIds.length - result.notDeleted.length} swaps cleared. ${result.notDeleted.length} failed to delete.`,
+            description: `${readSwapIds.length - result.notDeleted.length} swaps deleted. ${result.notDeleted.length} failed to delete.`,
             variant: "destructive",
           });
         } else {
           toast({
             title: "Success",
-            description: "All read swap requests have been cleared.",
+            description: "All read swap requests have been deleted.",
           });
         }
 
@@ -221,14 +221,14 @@ const SwapHistoryTab: React.FC<SwapHistoryTabProps> = ({ idToName, onPendingCoun
       } else {
         toast({
           title: "Error",
-          description: "Failed to clear swap requests.",
+          description: "Failed to delete swap requests.",
           variant: "destructive",
         });
       }
     } catch {
       toast({
         title: "Error",
-        description: "An error occurred while clearing swaps.",
+        description: "An error occurred while deleting swaps.",
         variant: "destructive",
       });
     }
@@ -290,10 +290,10 @@ const SwapHistoryTab: React.FC<SwapHistoryTabProps> = ({ idToName, onPendingCoun
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-4 gap-2">
         <h2 className="text-lg sm:text-xl font-bold mb-4">Swap Call History</h2>
         <ConfirmDialog
-          triggerText={<><X className="h-4 w-4" /><span>Clear</span></>}
-          title="Clear all read swap requests?"
-          message="Requests not marked as READ will not be cleared. This action cannot be undone."
-          confirmText="Clear"
+          triggerText={<><Trash2 className="h-4 w-4" /><span>Delete Requests</span></>}
+          title="Delete all read swap requests?"
+          message="Unread requests will not be deleted. This action cannot be undone."
+          confirmText="Delete"
           cancelText="Cancel"
           onConfirm={handleClearReadSwaps}
           variant="danger"
@@ -478,7 +478,7 @@ const VacationRequestsTab: React.FC<VacationRequestsTabProps> = ({ handleApprove
   const handleClearAllRequests = async () => {
     const vacationIds = requests.filter(r => r.status !== 'Pending').map(r => r.id);
     if (vacationIds.length === 0) {
-      toast({ title: 'No requests to clear', description: 'There are no vacation requests to delete.' });
+      toast({ title: 'No requests to delete', description: 'There are no vacation requests to delete.' });
       return;
     }
     try {
@@ -492,18 +492,18 @@ const VacationRequestsTab: React.FC<VacationRequestsTabProps> = ({ handleApprove
         if (result.notDeleted && result.notDeleted.length > 0) {
           toast({
             title: 'Partial success',
-            description: `${vacationIds.length - result.notDeleted.length} requests cleared. ${result.notDeleted.length} failed to delete.`,
+            description: `${vacationIds.length - result.notDeleted.length} requests deleted. ${result.notDeleted.length} failed to delete.`,
             variant: 'destructive',
           });
         } else {
-          toast({ title: 'Success', description: 'All vacation requests have been cleared.' });
+          toast({ title: 'Success', description: 'All vacation requests have been deleted.' });
         }
         fetchVacations();
       } else {
-        toast({ title: 'Error', description: 'Failed to clear vacation requests.', variant: 'destructive' });
+        toast({ title: 'Error', description: 'Failed to delete vacation requests.', variant: 'destructive' });
       }
     } catch {
-      toast({ title: 'Error', description: 'An error occurred while clearing requests.', variant: 'destructive' });
+      toast({ title: 'Error', description: 'An error occurred while deleting requests.', variant: 'destructive' });
     }
   };
 
@@ -596,10 +596,10 @@ const VacationRequestsTab: React.FC<VacationRequestsTabProps> = ({ handleApprove
               <span>Search</span>
             </Button>
             <ConfirmDialog
-              triggerText={<><X className="h-4 w-4" /><span>Clear</span></>}
-              title="Clear all vacation requests?"
-              message="This action cannot be undone. Pending requests will not be deleted."
-              confirmText="Clear"
+              triggerText={<><Trash2 className="h-4 w-4" /><span>Delete Requests</span></>}
+              title="Delete all vacation requests?"
+              message="Pending requests will not be deleted. This action cannot be undone."
+              confirmText="Delete"
               cancelText="Cancel"
               onConfirm={handleClearAllRequests}
               variant="danger"
@@ -816,7 +816,7 @@ const UserManagementTab: React.FC<UserManagementTabProps> = ({
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                         <Button variant="outline" size="sm" className="text-red-600 border-red-600 hover:bg-red-500 hover:text-white" onClick={() => handleDeleteUserWithConfirm(user)}>
-                          Delete
+                          <Trash2 className="h-4 w-4 mr-1 inline" />Delete
                         </Button>
                       </td>
                     </tr>
@@ -1151,7 +1151,7 @@ const AdminPage: React.FC<AdminPageProps> = ({
                       onClick={() => handleDeleteAnnouncement(a.announcementId)}
                       disabled={deletingAnnouncement === a.announcementId}
                     >
-                      {deletingAnnouncement === a.announcementId ? 'Deleting...' : 'Delete'}
+                      <Trash2 className="h-4 w-4 mr-1 inline" />{deletingAnnouncement === a.announcementId ? 'Deleting...' : 'Delete'}
                     </Button>
                   </div>
                 </div>

--- a/frontend/src/app/dashboard/components/AdminPage.tsx
+++ b/frontend/src/app/dashboard/components/AdminPage.tsx
@@ -336,22 +336,6 @@ const SwapHistoryTab: React.FC<SwapHistoryTabProps> = ({ idToName, onPendingCoun
                             }}>
                               <Check className="h-3 w-3 mr-1" /> Mark as Read
                             </Button>
-                            <ConfirmDialog
-                              open={!!warnReadId}
-                              onOpenChange={(open) => {
-                                if (!open) setWarnReadId(null);
-                              }}
-                              title="Mark pending request as read?"
-                              message="This swap request is still pending. Marking it as read makes it possible to delete. Mark as read anyway?"
-                              confirmText="Mark as Read"
-                              cancelText="Cancel"
-                              onConfirm={async () => {
-                                if (warnReadId) {
-                                  await handleMarkAsRead(warnReadId);
-                                  setWarnReadId(null);
-                                }
-                              }}
-                              />
                           </>
                         ) : (
                           <Button variant="outline" size="sm" className="mr-2 text-slate-600 hover:text-slate-600 border-slate-600" onClick={() => (/*Possible future implementation of marking as unread*/ "")}>
@@ -370,6 +354,22 @@ const SwapHistoryTab: React.FC<SwapHistoryTabProps> = ({ idToName, onPendingCoun
           </tbody>
         </table>
       </div>
+      <ConfirmDialog
+        open={!!warnReadId}
+        onOpenChange={(open) => {
+          if (!open) setWarnReadId(null);
+        }}
+        title="Mark pending request as read?"
+        message="This swap request is still pending. Marking it as read makes it possible to delete. Mark as read anyway?"
+        confirmText="Mark as Read"
+        cancelText="Cancel"
+        onConfirm={async () => {
+          if (warnReadId) {
+            await handleMarkAsRead(warnReadId);
+            setWarnReadId(null);
+          }
+        }}
+      />
     </Card>
   );
 };

--- a/frontend/src/app/dashboard/components/AdminPage.tsx
+++ b/frontend/src/app/dashboard/components/AdminPage.tsx
@@ -181,35 +181,57 @@ const SwapHistoryTab: React.FC<SwapHistoryTabProps> = ({ idToName, onPendingCoun
   }, [onPendingCountChange]);
 
   const handleClearReadSwaps = async () => {
-    /*const vacationIds = requests.map(r => r.id);
-    if (vacationIds.length === 0) {
-      toast({ title: 'No requests to clear', description: 'There are no vacation requests to delete.' });
+    const readSwapIds = swapHistory.filter((swap) => swap.isRead).map((swap) => swap.swapRequestId);
+
+    if (readSwapIds.length === 0) {
+      toast({
+        title: "No swaps to clear",
+        description: "There are no read swap requests to delete.",
+      });
       return;
     }
+
     try {
-      const response = await fetch(`${config.apiUrl}/api/vacations`, {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(vacationIds),
+      const response = await fetch(`${config.apiUrl}/api/SwapRequests`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(readSwapIds),
       });
+
       if (response.ok) {
         const result = await response.json();
+
         if (result.notDeleted && result.notDeleted.length > 0) {
           toast({
-            title: 'Partial success',
-            description: `${vacationIds.length - result.notDeleted.length} requests cleared. ${result.notDeleted.length} failed to delete.`,
-            variant: 'destructive',
+            title: "Partial success",
+            description: `${readSwapIds.length - result.notDeleted.length} swaps cleared. ${result.notDeleted.length} failed to delete.`,
+            variant: "destructive",
           });
         } else {
-          toast({ title: 'Success', description: 'All vacation requests have been cleared.' });
+          toast({
+            title: "Success",
+            description: "All read swap requests have been cleared.",
+          });
         }
-        fetchVacations();
+
+        setSwapHistory((prev) =>
+          prev.filter((swap) => !swap.isRead)
+        );
+
       } else {
-        toast({ title: 'Error', description: 'Failed to clear vacation requests.', variant: 'destructive' });
+        toast({
+          title: "Error",
+          description: "Failed to clear swap requests.",
+          variant: "destructive",
+        });
       }
     } catch {
-      toast({ title: 'Error', description: 'An error occurred while clearing requests.', variant: 'destructive' });
-    }*/
+      toast({
+        title: "Error",
+        description: "An error occurred while clearing swaps.",
+        variant: "destructive",
+      });
+    }
   };
 
   const handleMarkAsRead = async (swapId: string) => {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -987,13 +987,23 @@ case "Home":
         );
 
       case "Swap Calls": {
-        const pgyMatchedResidents = residents.filter(r => r.resident_id !== user?.id)
-          .map(r => ({ id: r.resident_id, name: `${r.first_name} ${r.last_name}` }));
         const now = new Date(); now.setHours(0, 0, 0, 0);
         const filterShiftEvents = (residentId: string) =>
           calendarEvents
             .filter(e => (e.extendedProps?.residentId || "").trim() === residentId.trim() && new Date(e.start) >= now)
             .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+        const swapAcademicYearOf = (date: Date) => date.getMonth() >= 6 ? date.getFullYear() : date.getFullYear() - 1;
+        const selectedShiftYear = yourShiftDate ? swapAcademicYearOf(new Date(yourShiftDate)) : null;
+        const pgyMatchedResidents = residents
+          .filter(r => r.resident_id !== user?.id)
+          .filter(r => {
+            const shifts = filterShiftEvents(r.resident_id);
+            if (selectedShiftYear !== null) {
+              return shifts.some(e => swapAcademicYearOf(e.start instanceof Date ? e.start : new Date(e.start)) === selectedShiftYear);
+            }
+            return shifts.length > 0;
+          })
+          .map(r => ({ id: r.resident_id, name: `${r.first_name} ${r.last_name}` }));
         const userShiftEvents = user?.id ? filterShiftEvents(user.id) : [];
         const partnerShiftEvents = selectedResident ? filterShiftEvents(selectedResident) : [];
         return (


### PR DESCRIPTION
Added one back-end change to allow for pending swaps to be deleted. 
Pending swaps contain a confirm dialogue when admin attempts to mark it as read to warn them.
Bulk clear button on admin side deletes all read swaps.
After a swap is marked as read, a new button stylized to not have functionality shows it's read. 
Swaps are sorted to have unread swaps at the top with a yellow-tinted background.