### PR TITLE
PSY-128: add GET and DELETE endpoints for invites

### DIFF
--- a/backend/Controllers/InviteController.cs
+++ b/backend/Controllers/InviteController.cs
@@ -96,10 +96,7 @@ namespace MedicalDemo.Controllers
         [HttpGet]
         public async Task<ActionResult<List<InviteResponse>>> GetAllInvitations()
         {
-            // Only return invites within the past week
-            DateTime windowCutoff = DateTime.UtcNow.AddDays(-7);
             List<Invitation> invitations = await _context.Invitations
-                .Where(i => i.Expires > windowCutoff && !i.Used)
                 .ToListAsync();
 
             IEnumerable<string> residentIds
@@ -109,11 +106,11 @@ namespace MedicalDemo.Controllers
                 .Where(r => residentIds.Contains(r.ResidentId))
                 .ToDictionaryAsync(r => r.ResidentId);
 
-            Resident? ResidetnSelector(string? id) => id == null ? null : residents.GetValueOrDefault(id);
+            Resident? ResidentSelector(string? id) => id == null ? null : residents.GetValueOrDefault(id);
 
             return Ok(
                 invitations.Select(
-                    invitation => _invitationConverter.CreateInvitationResponseFromModel(invitation, ResidetnSelector(invitation.ResidentId))
+                    invitation => _invitationConverter.CreateInvitationResponseFromModel(invitation, ResidentSelector(invitation.ResidentId))
                 )
             );
         }

--- a/backend/Controllers/InviteController.cs
+++ b/backend/Controllers/InviteController.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using MedicalDemo.Converters;
 using MedicalDemo.Interfaces;
 using MedicalDemo.Models;
 using MedicalDemo.Models.DTO.Requests;
@@ -14,15 +16,18 @@ namespace MedicalDemo.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
+    [SuppressMessage("Performance", "CA1862:Use the \'StringComparison\' method overloads to perform case-insensitive string comparisons")]
     public class InviteController : ControllerBase
     {
         private readonly MedicalContext _context;
         private readonly IEmailSendService _emailSendService;
+        private readonly InvitationConverter _invitationConverter;
 
-        public InviteController(MedicalContext context, IEmailSendService emailSendService)
+        public InviteController(MedicalContext context, IEmailSendService emailSendService, InvitationConverter invitationConverter)
         {
             _context = context;
             _emailSendService = emailSendService;
+            _invitationConverter = invitationConverter;
         }
 
         [HttpPost("send")]
@@ -37,11 +42,18 @@ namespace MedicalDemo.Controllers
             string token = Guid.NewGuid().ToString();
             DateTime expires = DateTime.UtcNow.AddHours(24);
 
+            if (await _context.Invitations.AnyAsync(i => i.Email.ToLower() == createRequest.Email.ToLower()))
+            {
+                return BadRequest(
+                    GenericResponse.Failure("An invitation for that email already exists"));
+            }
+
             //Save token to Invitations table
             Invitation invitation = new()
             {
                 Token = token,
                 ResidentId = resident?.ResidentId,
+                Email = createRequest.Email,
                 Expires = expires,
                 Used = false
             };
@@ -68,17 +80,56 @@ namespace MedicalDemo.Controllers
 
             if (!success)
             {
-                return StatusCode(500, new InviteResponse
+                return StatusCode(500, new GenericResponse
                 {
                     Success = false,
                     Message = "Email sending failed."
                 });
             }
 
-            return Ok(new InviteResponse
+            return Ok(new GenericResponse
             {
                 Success = true
             });
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<List<InviteResponse>>> GetAllInvitations()
+        {
+            // Only return invites within the past week
+            DateTime windowCutoff = DateTime.UtcNow.AddDays(-7);
+            List<Invitation> invitations = await _context.Invitations
+                .Where(i => i.Expires > windowCutoff && !i.Used)
+                .ToListAsync();
+
+            IEnumerable<string> residentIds
+                = invitations.Where(i => i.ResidentId != null).Select(i => i.ResidentId!);
+
+            Dictionary<string, Resident> residents = await _context.Residents
+                .Where(r => residentIds.Contains(r.ResidentId))
+                .ToDictionaryAsync(r => r.ResidentId);
+
+            Resident? ResidetnSelector(string? id) => id == null ? null : residents.GetValueOrDefault(id);
+
+            return Ok(
+                invitations.Select(
+                    invitation => _invitationConverter.CreateInvitationResponseFromModel(invitation, ResidetnSelector(invitation.ResidentId))
+                )
+            );
+        }
+
+        [HttpDelete("{email}")]
+        public async Task<ActionResult> DeleteInvitation([FromRoute] string email)
+        {
+            Invitation? invitation = await _context.Invitations.FirstOrDefaultAsync(i => i.Email.ToLower() == email.ToLower());
+            if (invitation == null)
+            {
+                return BadRequest(GenericResponse.Failure("No invitation with that email exists"));
+            }
+
+            _context.Invitations.Remove(invitation);
+            await _context.SaveChangesAsync();
+            return NoContent();
         }
     }
 }

--- a/backend/Converters/InvitationConverter.cs
+++ b/backend/Converters/InvitationConverter.cs
@@ -1,0 +1,19 @@
+using MedicalDemo.Models.DTO.Responses;
+using MedicalDemo.Models.Entities;
+
+namespace MedicalDemo.Converters;
+
+public class InvitationConverter
+{
+    public InviteResponse CreateInvitationResponseFromModel(Invitation invitation, Resident? resident)
+    {
+        return new InviteResponse()
+        {
+            ResidentId = invitation.ResidentId,
+            FirstName = resident?.FirstName,
+            LastName = resident?.LastName,
+            Email = invitation.Email,
+            Expires = new DateTimeOffset(invitation.Expires, TimeSpan.Zero),
+        };
+    }
+}

--- a/backend/Extensions/WebApplicationBuilderExtensions.cs
+++ b/backend/Extensions/WebApplicationBuilderExtensions.cs
@@ -49,6 +49,7 @@ public static class WebApplicationBuilderExtensions
         builder.Services.AddScoped<AnnouncementConverter>();
         builder.Services.AddScoped<BlackoutConverter>();
         builder.Services.AddScoped<DateConverter>();
+        builder.Services.AddScoped<InvitationConverter>();
         builder.Services.AddScoped<ResidentConverter>();
         builder.Services.AddScoped<ScheduleConverter>();
         builder.Services.AddScoped<SwapRequestConverter>();

--- a/backend/Migrations/20260414231148_AddEmailColumnToInvitations.Designer.cs
+++ b/backend/Migrations/20260414231148_AddEmailColumnToInvitations.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MedicalDemo.Models.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace MedicalDemo.Migrations
 {
     [DbContext(typeof(MedicalContext))]
-    partial class MedicalContextModelSnapshot : ModelSnapshot
+    [Migration("20260414231148_AddEmailColumnToInvitations")]
+    partial class AddEmailColumnToInvitations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20260414231148_AddEmailColumnToInvitations.cs
+++ b/backend/Migrations/20260414231148_AddEmailColumnToInvitations.cs
@@ -1,0 +1,46 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MedicalDemo.Migrations
+{
+    public partial class AddEmailColumnToInvitations : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "expires",
+                table: "invitations",
+                type: "datetime",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Email",
+                table: "invitations",
+                type: "longtext",
+                nullable: false,
+                collation: "utf8mb4_0900_ai_ci")
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Email",
+                table: "invitations");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "expires",
+                table: "invitations",
+                type: "datetime",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime");
+        }
+    }
+}

--- a/backend/Models/DTO/Responses/InviteResponse.cs
+++ b/backend/Models/DTO/Responses/InviteResponse.cs
@@ -1,6 +1,10 @@
 namespace MedicalDemo.Models.DTO.Responses;
 
-public class InviteResponse : GenericResponse
+public class InviteResponse
 {
-
+    public string? ResidentId { get; set; }
+    public string? FirstName { get; set; }
+    public string? LastName { get; set; }
+    public required string Email { get; set; }
+    public DateTimeOffset Expires { get; set; }
 }

--- a/backend/Models/Entities/Invitation.cs
+++ b/backend/Models/Entities/Invitation.cs
@@ -2,9 +2,10 @@ namespace MedicalDemo.Models.Entities
 {
     public partial class Invitation
     {
-        public string Token { get; set; } = null!;
+        public required string Token { get; set; } = null!;
         public string? ResidentId { get; set; }
-        public DateTime? Expires { get; set; }
+        public required string Email { get; set; }
+        public DateTime Expires { get; set; }
         public bool Used { get; set; }
     }
 }


### PR DESCRIPTION
Add GET and DELETE endpoints for invites

- The GET endpoint returns all invites within the past week that have not been used. The fields ResidentId, FirstName, and LastName will be filled out if it is an existing resident (password reset request/information change)
- Emails are now stored with invitations for distinction, but the email submitted on the register form is not required to match who the invite was sent to. Not sure if they are allowed to use any email they'd like to sign up, so figured I would just leave that be.